### PR TITLE
fix(core:modal): fix modal and popup animations

### DIFF
--- a/packages/core/src/dropdown/dropdown.stories.ts
+++ b/packages/core/src/dropdown/dropdown.stories.ts
@@ -69,7 +69,7 @@ class DemoDropdownBasic extends DemoDropdown {
         @closeChange=${() => (this.showOverlay = false)}
       >
         <cds-internal-pointer type="angle"></cds-internal-pointer>
-        <div cds-layout="vertical gap:lg p:lg align:stretch">
+        <div cds-layout="vertical gap:lg align:stretch">
           <h3 cds-first-focus cds-text="section" id="basic-dropdown-title">Dropdown</h3>
           <p cds-text="body">Any content can be placed inside a generic dropdown.</p>
           <cds-button style="max-height: 36px" type="button" @click=${() => (this.showOverlay = false)}
@@ -103,7 +103,7 @@ class DemoDropdownScrollable extends DemoDropdown {
         id="demo-dropdown-scrollable-dd"
         @closeChange=${() => (this.showOverlay = false)}
       >
-        <div cds-layout="vertical gap:lg p-y:lg align:stretch">
+        <div cds-layout="vertical gap:lg align:stretch">
           <h3 cds-first-focus cds-text="section" cds-layout="p-x:lg" id="scrolling-dropdown-title">
             Scrollable Dropdown
           </h3>
@@ -239,7 +239,7 @@ class DemoDropdownPointer extends DemoDropdown {
         anchor="demo-pointer-anchor"
         @closeChange=${() => (this.showOverlay = false)}
       >
-        <div cds-layout="vertical gap:lg p:lg align:stretch">
+        <div cds-layout="vertical gap:lg align:stretch">
           <h3 cds-first-focus cds-text="section" id="pointer-dropdown-title">Dropdown With Pointer</h3>
           <p cds-text="body">Any content can be placed inside a generic dropdown.</p>
           <cds-button style="max-height: 36px" type="button" @click=${() => (this.showOverlay = false)}
@@ -270,7 +270,7 @@ class DemoDropdownResponsive extends DemoDropdown {
         anchor="demo-responsive-anchor"
         @closeChange=${() => (this.showOverlay = false)}
       >
-        <div cds-layout="vertical gap:lg p:lg align:stretch">
+        <div cds-layout="vertical gap:lg align:stretch">
           <h3 cds-first-focus cds-text="section" id="responsive-dropdown-title">Responsive Dropdown</h3>
           <div cds-layout="vertical gap:lg">
             <p cds-text="body">
@@ -313,7 +313,7 @@ class DemoDropdownClosable extends DemoDropdown {
         id="demo-closable-dd"
         @closeChange=${() => (this.showOverlay = false)}
       >
-        <div cds-layout="vertical gap:lg p:lg align:stretch">
+        <div cds-layout="vertical gap:lg align:stretch">
           <h3 cds-first-focus cds-text="section" id="closable-dropdown-title">Closable Dropdown</h3>
           <div cds-layout="vertical gap:lg">
             <p cds-text="body">
@@ -360,7 +360,7 @@ class DemoDropdownAltAnchored extends DemoDropdown {
         id="demo-anchored-dd"
         @closeChange=${() => (this.showOverlay = false)}
       >
-        <div cds-layout="vertical gap:lg p:lg align:stretch">
+        <div cds-layout="vertical gap:lg align:stretch">
           <h3 cds-first-focus cds-text="section" id="anchored-dropdown-title">Anchored Dropdown</h3>
           <div cds-layout="vertical gap:lg">
             <p cds-text="body">A dropdown can be anchored to any element on the page.</p>
@@ -478,7 +478,7 @@ class DemoDropdownOrientation extends DemoDropdown {
         id="demo-orientations-dd"
         @closeChange=${() => (this.showOverlay = false)}
       >
-        <div cds-layout="vertical gap:lg p:lg align:stretch">
+        <div cds-layout="vertical gap:lg align:stretch">
           <h3 cds-first-focus cds-text="section" id="orientation-dropdown-title">Dropdown Orientation</h3>
           <p cds-text="body">
             The preference for where the dropdown should be placed can be changed to suit the requirements of your
@@ -515,7 +515,7 @@ class DemoDropdownDarkTheme extends DemoDropdown {
         id="demo-dark-dd"
         @closeChange=${() => (this.showOverlay = false)}
       >
-        <div cds-layout="vertical gap:lg p:lg align:stretch">
+        <div cds-layout="vertical gap:lg align:stretch">
           <h3 cds-first-focus cds-text="section" id="dark-theme-title">Dropdown</h3>
           <p cds-text="body">Any content can be placed inside a generic dropdown.</p>
           <cds-button style="max-height: 36px" type="button" @click=${() => (this.showOverlay = false)}
@@ -565,7 +565,7 @@ class DemoDropdownInModal extends DemoDropdown {
         anchor="ddown-anchor"
         @closeChange=${() => (this.showDropdown = false)}
       >
-        <div cds-layout="vertical gap:lg p:lg align:stretch">
+        <div cds-layout="vertical gap:lg align:stretch">
           <h3 cds-first-focus cds-text="section" id="ddown-modal-title">Dropdown</h3>
           <p cds-text="body">Any content can be placed inside a generic dropdown.</p>
           <cds-button style="max-height: 36px" type="button" @click=${() => (this.showDropdown = false)}

--- a/packages/core/src/grid/docs/row-action.story.ts
+++ b/packages/core/src/grid/docs/row-action.story.ts
@@ -43,7 +43,7 @@ export function rowAction() {
           .anchor=${this.anchor}
           @closeChange=${() => (this.activeRow = null) as any}
         >
-          <div cds-layout="vertical align:stretch p:xs">
+          <div cds-layout="vertical align:stretch">
             ${this.grid.rowActions.map(
               action =>
                 html`<cds-button action="flat" size="sm" @click=${() => this.action(action.value, this.activeRow)}

--- a/packages/core/src/internal-components/overlay/overlay.element.spec.ts
+++ b/packages/core/src/internal-components/overlay/overlay.element.spec.ts
@@ -16,7 +16,9 @@ describe('Overlay element: ', () => {
   const placeholderText = 'Placeholder';
 
   beforeEach(async () => {
-    testElement = await createTestElement(html`<cds-internal-overlay>${placeholderText}</cds-internal-overlay>`);
+    testElement = await createTestElement(
+      html`<cds-internal-overlay cds-motion="off">${placeholderText}</cds-internal-overlay>`
+    );
     component = testElement.querySelector<CdsInternalOverlay>('cds-internal-overlay');
   });
 
@@ -26,14 +28,22 @@ describe('Overlay element: ', () => {
 
   describe('the basics - ', () => {
     it('should create the component', async () => {
+      component.hidden = false;
       await componentIsStable(component);
       expect(component.innerText.includes(placeholderText)).toBe(true);
     });
 
     it('inner panel should exist', async () => {
+      component.hidden = false;
       await componentIsStable(component);
       const innerPanel = component.shadowRoot.querySelector('.private-host');
       expect(innerPanel).toBeTruthy('inner panel should exist');
+    });
+
+    it('should default to the hidden property being true', async () => {
+      await componentIsStable(component);
+      expect(component.hidden).toBe(true);
+      expect(component.hasAttribute('hidden')).toBe(true);
     });
   });
 
@@ -53,7 +63,9 @@ describe('Overlay behaviors: ', () => {
   const placeholderText = 'Placeholder';
 
   beforeEach(async () => {
-    testElement = await createTestElement(html`<cds-internal-overlay>${placeholderText}</cds-internal-overlay>`);
+    testElement = await createTestElement(
+      html`<cds-internal-overlay cds-motion="off">${placeholderText}</cds-internal-overlay>`
+    );
     component = testElement.querySelector<CdsInternalOverlay>('cds-internal-overlay');
     await componentIsStable(component);
     component.closable = true;
@@ -112,7 +124,9 @@ class NestedOverlayTestComponent extends LitElement {
   }
 
   render() {
-    return html`<cds-internal-overlay id=${this.overlayId}><slot></slot></cds-internal-overlay>`;
+    return html`<cds-internal-overlay id=${this.overlayId} cds-motion="off" .hidden=${false}
+      ><slot></slot
+    ></cds-internal-overlay>`;
   }
 }
 
@@ -125,10 +139,14 @@ describe('Nested overlays: ', () => {
 
   beforeEach(async () => {
     testElement = await createTestElement(
-      html`<nested-overlay-test-component id="root" overlay-id="rootOverlay"
-        >${placeholderText}<nested-overlay-test-component id="second" overlay-id="secondOverlay"
+      html`<nested-overlay-test-component id="root" overlay-id="rootOverlay" cds-motion="off" .hidden=${false}
+        >${placeholderText}<nested-overlay-test-component
+          id="second"
+          overlay-id="secondOverlay"
+          cds-motion="off"
+          .hidden=${false}
           >Ohai</nested-overlay-test-component
-        ><nested-overlay-test-component id="third" overlay-id="thirdOverlay"
+        ><nested-overlay-test-component id="third" overlay-id="thirdOverlay" cds-motion="off" .hidden=${false}
           >Kthxbye</nested-overlay-test-component
         ></nested-overlay-test-component
       >`

--- a/packages/core/src/internal-components/overlay/overlay.element.ts
+++ b/packages/core/src/internal-components/overlay/overlay.element.ts
@@ -38,6 +38,9 @@ import sharedStyles from './shared.element.scss';
 export class CdsInternalStaticOverlay extends LitElement {
   @property({ type: Boolean }) closable = false;
 
+  // eslint-disable-next-line rulesdir/reserved-property-names
+  @property({ type: Boolean }) hidden = true;
+
   @state({ type: Boolean, reflect: true }) protected demoMode = false;
 
   @i18n() i18n = I18nService.keys.overlay;

--- a/packages/core/src/internal/positioning/utils.spec.ts
+++ b/packages/core/src/internal/positioning/utils.spec.ts
@@ -50,7 +50,7 @@ function createPopupContent() {
 @customElement('positioning-utils-test-popup')
 class PositioningUtilsTestPopup extends LitElement {
   render() {
-    return html` <cds-internal-popup>${createPopupContent()}</cds-internal-popup>`;
+    return html` <cds-internal-popup .hidden=${false}>${createPopupContent()}</cds-internal-popup>`;
   }
 }
 
@@ -58,7 +58,7 @@ class PositioningUtilsTestPopup extends LitElement {
 class PositioningUtilsTestPopupWithPointer extends LitElement {
   pointerType: 'default' | 'angle' = 'angle';
   render() {
-    return html` <cds-internal-popup>
+    return html` <cds-internal-popup .hidden=${false}>
       <cds-internal-pointer type=${this.pointerType}></cds-internal-pointer>
       ${createPopupContent()}
     </cds-internal-popup>`;

--- a/packages/core/src/internal/utils/dom.spec.ts
+++ b/packages/core/src/internal/utils/dom.spec.ts
@@ -453,6 +453,11 @@ describe('Functional Helper: ', () => {
 
       expect(isScrollable(element)).toBe(false);
     });
+
+    it('should not panic if passed a non-element', () => {
+      expect(isScrollable(null)).toBe(false);
+      expect(isScrollable(void 0)).toBe(false);
+    });
   });
 
   describe('isFocusable() ', () => {
@@ -506,10 +511,10 @@ describe('Functional Helper: ', () => {
       });
       it('selects return true', async () => {
         testElement = await createTestElement(
-          html`<select id="${testId}"
-            ><option selected>ohai</option
-            ><option>kthxbye</option></select
-          >`
+          html`<select id="${testId}">
+            <option selected>ohai</option>
+            <option>kthxbye</option>
+          </select>`
         );
         expect(isFocusable(testElement.querySelector('#' + testId))).toBe(true);
       });

--- a/packages/core/src/internal/utils/dom.ts
+++ b/packages/core/src/internal/utils/dom.ts
@@ -54,6 +54,11 @@ export function isFocusable(element: HTMLElement) {
 
 /* c8 ignore next */
 export function isScrollable(element: HTMLElement) {
+  // early return here in the event element looked up but not in the dom at present
+  if (!element) {
+    return false;
+  }
+
   // there's no great way to determine if something has scrollbars or not
   // this calculation is... okay at it. it is slightly naive but covers
   // our current need/use-case. if we need something more robust, we can

--- a/packages/core/src/modal/modal.element.spec.ts
+++ b/packages/core/src/modal/modal.element.spec.ts
@@ -28,7 +28,7 @@ describe('modal element', () => {
 
   beforeEach(async () => {
     testElement = await createTestElement(html`
-      <cds-modal id="normal-modal" hidden>
+      <cds-modal id="normal-modal" hidden cds-motion="off">
         <cds-modal-header>${placeholderHeader}</cds-modal-header>
         <cds-modal-content
           ><div><p>${placeholderContent}</p></div></cds-modal-content

--- a/packages/core/src/modal/modal.element.ts
+++ b/packages/core/src/modal/modal.element.ts
@@ -141,11 +141,12 @@ export class CdsModal extends CdsInternalOverlay {
   }
 
   private async setScrollableProperties() {
-    if (this.hidden === false) {
+    const contentElement = this.content;
+    if (this.hidden === false && contentElement !== null) {
       await this.updateComplete; // wait until after render to measure if scrollable
-      this.isScrollable = isScrollable(this.content);
-      this.content.tabIndex = this.isScrollable ? 0 : -1;
-      this.content.ariaLabel = this.isScrollable ? this.i18n.contentBox : null;
+      this.isScrollable = isScrollable(contentElement);
+      contentElement.tabIndex = this.isScrollable ? 0 : -1;
+      contentElement.ariaLabel = this.isScrollable ? this.i18n.contentBox : null;
     }
   }
 }

--- a/packages/core/src/modal/modal.stories.ts
+++ b/packages/core/src/modal/modal.stories.ts
@@ -82,7 +82,7 @@ class DemoStaticModal extends LitElement {
 
   render() {
     return html` <cds-demo popover>
-      <cds-modal _demo-mode size=${this.size} aria-labelledby=${this.labelId}>
+      <cds-modal _demo-mode size=${this.size} aria-labelledby=${this.labelId} .hidden=${false}>
         <cds-modal-header>
           <h3 cds-text="section" cds-first-focus id=${this.labelId}>${this.modalDisplaySize} Modal</h3>
         </cds-modal-header>
@@ -109,7 +109,7 @@ small.element = DemoStaticModal;
 export function defaultSize() {
   return html`
     <cds-demo popover>
-      <cds-modal _demo-mode aria-labelledby="default-modal-title">
+      <cds-modal _demo-mode aria-labelledby="default-modal-title" .hidden=${false}>
         <cds-modal-header>
           <h3 cds-text="section" cds-first-focus id="default-modal-title">Modal Example</h3>
         </cds-modal-header>
@@ -129,7 +129,7 @@ export function defaultSize() {
 export function large() {
   return html`
     <cds-demo popover>
-      <cds-modal _demo-mode size="lg" aria-labelledby="large-modal-title">
+      <cds-modal _demo-mode size="lg" aria-labelledby="large-modal-title" .hidden=${false}>
         <cds-modal-header>
           <h3 cds-text="section" cds-first-focus id="large-modal-title">Large Modal Example</h3>
         </cds-modal-header>
@@ -149,7 +149,7 @@ export function large() {
 export function extraLarge() {
   return html`
     <cds-demo popover>
-      <cds-modal _demo-mode size="xl" aria-labelledby="xl-modal-title">
+      <cds-modal _demo-mode size="xl" aria-labelledby="xl-modal-title" .hidden=${false}>
         <cds-modal-header>
           <h3 cds-text="section" cds-first-focus id="xl-modal-title">Extra Large Modal Example</h3>
         </cds-modal-header>
@@ -169,7 +169,7 @@ export function extraLarge() {
 export function darkTheme() {
   return html`
     <cds-demo popover cds-theme="dark">
-      <cds-modal _demo-mode aria-labelledby="dark-modal-title">
+      <cds-modal _demo-mode aria-labelledby="dark-modal-title" .hidden=${false}>
         <cds-modal-header>
           <h3 cds-text="section" cds-first-focus id="dark-modal-title">My Modal</h3>
         </cds-modal-header>
@@ -207,7 +207,7 @@ export function customStyles() {
     </style>
 
     <cds-demo popover>
-      <cds-modal _demo-mode class="modal-branding" size="lg" aria-labelledby="custom-modal-title">
+      <cds-modal _demo-mode class="modal-branding" size="lg" aria-labelledby="custom-modal-title" .hidden=${false}>
         <cds-modal-header>
           <h3 cds-text="section" cds-first-focus id="custom-modal-title">Customizing Modal Styles</h3>
         </cds-modal-header>
@@ -229,11 +229,11 @@ export function focus() {
 
   function showFocusModal() {
     const myOverlay = document.getElementById(modalId) as CdsModal;
-    myOverlay.removeAttribute('hidden');
+    myOverlay.hidden = false;
 
     if (!initted) {
       myOverlay.addEventListener('closeChange', () => {
-        myOverlay.setAttribute('hidden', 'true');
+        myOverlay.hidden = true;
       });
       initted = true;
     }


### PR DESCRIPTION
Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

There was a regression in `6.0.0-next.4` that broke the animations for the dropdowns and modals (all overlays).

The animations for those components rely on the `hidden` property. But we had introduced an eslint to block certain keywords from being used as properties. This was to prevent Safari from breaking on the AOM when working with properties that mapped to aria attrs.

`hidden` is not an aria attr. So it doesn't seem to mess up the AOM (Accessibility Object Model - the DOM but for accessibility!).

I also addressed a few padding issues I saw in the demos for signposts, dropdowns and grid row actions.

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
