### PR TITLE
fix(react:panel): use correct element in CdsRadioPanel

### DIFF
--- a/packages/react/src/selection-panels/radio/__snapshots__/index.test.tsx.snap
+++ b/packages/react/src/selection-panels/radio/__snapshots__/index.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`CdsRadioPanel snapshot 1`] = `
     <CdsRadioPanel
       l={null}
     >
-      <cds-radio
+      <cds-radio-panel
         l={null}
       >
         <label>
@@ -15,7 +15,7 @@ exports[`CdsRadioPanel snapshot 1`] = `
         <input
           type="checkbox"
         />
-      </cds-radio>
+      </cds-radio-panel>
     </CdsRadioPanel>
   </CdsRadioPanel>
 </div>

--- a/packages/react/src/selection-panels/radio/index.tsx
+++ b/packages/react/src/selection-panels/radio/index.tsx
@@ -4,6 +4,6 @@ import { createComponent } from '@lit-labs/react';
 import * as React from 'react';
 import { logReactVersion } from '../../utils/index.js';
 
-export const CdsRadioPanel = createComponent(React, 'cds-radio', RadioPanel, {}, 'CdsRadioPanel');
+export const CdsRadioPanel = createComponent(React, 'cds-radio-panel', RadioPanel, {}, 'CdsRadioPanel');
 
 logReactVersion(React);


### PR DESCRIPTION
Signed-off-by: David Sharp <dsharp@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

CdsRadioPanel is returning a wrapped version of cds-radio, not cds-radio-panel

Issue Number: #24 

## What is the new behavior?

It wraps the correct element, cds-radio

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
