### PR TITLE
fix(react:selection-panel): wrap cds-radio-panel instead of cds-radio

### DIFF
--- a/projects/react/src/selection-panels/radio/__snapshots__/index.test.tsx.snap
+++ b/projects/react/src/selection-panels/radio/__snapshots__/index.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`CdsRadioPanel snapshot 1`] = `
     <CdsRadioPanel
       l={null}
     >
-      <cds-radio
+      <cds-radio-panel
         l={null}
       >
         <label>
@@ -15,7 +15,7 @@ exports[`CdsRadioPanel snapshot 1`] = `
         <input
           type="checkbox"
         />
-      </cds-radio>
+      </cds-radio-panel>
     </CdsRadioPanel>
   </CdsRadioPanel>
 </div>

--- a/projects/react/src/selection-panels/radio/index.tsx
+++ b/projects/react/src/selection-panels/radio/index.tsx
@@ -4,6 +4,6 @@ import { createComponent } from '@lit-labs/react';
 import * as React from 'react';
 import { logReactVersion } from '../../utils/index.js';
 
-export const CdsRadioPanel = createComponent(React, 'cds-radio', RadioPanel, {}, 'CdsRadioPanel');
+export const CdsRadioPanel = createComponent(React, 'cds-radio-panel', RadioPanel, {}, 'CdsRadioPanel');
 
 logReactVersion(React);


### PR DESCRIPTION
CdsRadioPanel previously wrapped cds-radio, not cds-radio-panel

Fixes #24

Signed-off-by: Ashley Ryan <asryan@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

CdsRadioPanel should export cds-radio-panel, not cds-radio

Issue Number: #24 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
