### PR TITLE
chore: run core library build as part of public-api:update script

### DIFF
--- a/projects/core/package.json
+++ b/projects/core/package.json
@@ -7,7 +7,7 @@
     "build:watch": "npm run _build:lib -- --watch",
     "clean": "rimraf ./dist",
     "public-api:check": "filessert ./dist/lib/custom-elements.json ./custom-elements.json",
-    "public-api:update": "cpy ./dist/lib/custom-elements.json ./",
+    "public-api:update": "npm run build:lib && cpy ./dist/lib/custom-elements.json ./",
     "sandbox": "web-dev-server --config ./web-dev-server.sandbox.mjs",
     "start": "npm-run-all build --parallel build:watch _storybook:start",
     "test": "npm-run-all _test:unit _test:performance",


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

Running `npm run public-api:update` will now run the library build as part of the script so there are no prerequisites to running the script. This is the same way it works in the ng-clarity repo.

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe: