### PR TITLE
fix(input): keep input styling for input with size attributes

### DIFF
--- a/projects/core/src/input/input.element.scss
+++ b/projects/core/src/input/input.element.scss
@@ -30,7 +30,7 @@
 }
 
 // size/multiple are native select APIs
-::slotted([slot='input']:not([multiple]):not([size])) {
+::slotted([slot='input']:not(select[multiple]):not(select[size])) {
   text-transform: var(--text-transform) !important;
   border: var(--border) !important;
   padding: var(--padding);


### PR DESCRIPTION
fixes #55

Signed-off-by: Ashley Ryan <asryan@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When support for the `size` attribute was added for cds-select, it removed styling from all inputs using the `size` attribute, which is something pagination relies on and caused a visual regression

Issue Number: #55 

## What is the new behavior?

Limit the css to `select` elements using the `size` attribute

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

After:

<img width="1137" alt="image" src="https://user-images.githubusercontent.com/9469374/165792309-4aa0bdd4-50fd-4daa-801a-a7ea1fe15e2f.png">

<img width="1054" alt="image" src="https://user-images.githubusercontent.com/9469374/165792361-92619d4c-7956-4c71-bfac-7cb6d40957c1.png">

