### PR TITLE
fix(cds-icon): fix globalstateservice memory leak (backport)

### DIFF
--- a/projects/core/src/icon/icon.element.ts
+++ b/projects/core/src/icon/icon.element.ts
@@ -169,13 +169,15 @@ export class CdsIcon extends LitElement {
   firstUpdated(props: PropertyValues<this>) {
     super.firstUpdated(props);
 
-    let prior = 'unknown';
-    this.subscription = GlobalStateService.stateUpdates.subscribe(update => {
-      if (update.key === 'iconRegistry' && ClarityIcons.registry[this.shape] && prior !== this.shape) {
-        prior = this.shape;
-        this.requestUpdate('shape');
-      }
-    });
+    if (this.isConnected) {
+      let prior = 'unknown';
+      this.subscription = GlobalStateService.stateUpdates.subscribe(update => {
+        if (update.key === 'iconRegistry' && ClarityIcons.registry[this.shape] && prior !== this.shape) {
+          prior = this.shape;
+          this.requestUpdate('shape');
+        }
+      });
+    }
   }
 
   disconnectedCallback() {


### PR DESCRIPTION
ensure the component is connected before subscribing to the globalstateservice

Fixes #61

Signed-off-by: Ashley Ryan <asryan@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When an element is immediately removed from the DOM, `firstUpdated` can be called after `disconnectedCallback`, resulting in an event listener created that never gets removed.

https://developer.mozilla.org/en-US/docs/Web/API/Node/isConnected

https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements#using_the_lifecycle_callbacks

Issue Number: #61 

## What is the new behavior?

Added a check that the component is connected before creating the event listener

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
