### PR TITLE
chore: remove the Clarity Angular/UI in the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -24,11 +24,6 @@ _A clear and concise description of what you expected to happen._
 
 ## Versions
 
-**Clarity project:**
-
-- [ ] Clarity Core
-- [ ] Clarity Angular/UI
-
 **Clarity version:**
 
 - [ ] v5.x


### PR DESCRIPTION
Since the Clarity Angular/UI and Clarity Core projects have been split into 2 repos, I believe there is no longer a need for this.