### PR TITLE
fix(pagination): fix disabled css and remove full width

### DIFF
--- a/projects/core/src/pagination/pagination.element.scss
+++ b/projects/core/src/pagination/pagination.element.scss
@@ -12,7 +12,6 @@
   --action-color: var(--color);
   color: var(--color);
   display: flex;
-  width: 100%;
   flex-wrap: none;
   font-size: var(--font-size);
 }
@@ -31,7 +30,7 @@
   display: block;
 }
 
-::slotted(cds-pagination-button) {
+::slotted(cds-pagination-button:not([disabled])) {
   --color: var(--action-color);
 }
 

--- a/projects/core/src/pagination/pagination.stories.ts
+++ b/projects/core/src/pagination/pagination.stories.ts
@@ -262,16 +262,20 @@ export const customPaginationAlignments = () => {
       </cds-pagination>
     </div>
     <div cds-layout="m-y:sm">
-      <cds-pagination aria-label="pagination" cds-layout="horizontal gap:md align:right">
-        <cds-pagination-button aria-label="go to first" action="first" disabled></cds-pagination-button>
-        <cds-pagination-button aria-label="go to previous" action="prev" disabled></cds-pagination-button>
-        <cds-input cds-pagination-number>
-          <input type="text" value="40" size="2" aria-label="current page" />
-          <cds-control-message>/ 80</cds-control-message>
-        </cds-input>
-        <cds-pagination-button aria-label="go to next" action="next"></cds-pagination-button>
-        <cds-pagination-button aria-label="go to last" action="last"></cds-pagination-button>
-      </cds-pagination>
+      <div cds-layout="horizontal gap:md align:right align:vertical-center">
+        <span>Viewing 1-10 of 80</span>
+
+        <cds-pagination aria-label="pagination">
+          <cds-pagination-button aria-label="go to first" action="first" disabled></cds-pagination-button>
+          <cds-pagination-button aria-label="go to previous" action="prev" disabled></cds-pagination-button>
+          <cds-input cds-pagination-number>
+            <input type="text" value="40" size="2" aria-label="current page" />
+            <cds-control-message>/ 80</cds-control-message>
+          </cds-input>
+          <cds-pagination-button aria-label="go to next" action="next"></cds-pagination-button>
+          <cds-pagination-button aria-label="go to last" action="last"></cds-pagination-button>
+        </cds-pagination>
+      </div>
     </div>
     <div cds-layout="m-y:sm">
       <cds-pagination aria-label="pagination" cds-layout="vertical gap:md align:center">


### PR DESCRIPTION
closes #84 
closes #85

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

(#84) The disabled pagination button doesn't render as disabled
(#85) The pagination component automatically wraps

Issue Number: #84 #85

## What is the new behavior?

The disabled styling is fixed and the pagination component no longer takes up 100% width so can be combined with other content

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

![image](https://user-images.githubusercontent.com/9469374/172642232-7bdee186-030c-4340-8d76-5fddcfc23527.png)

