### PR TITLE
fix(button): revert disabled button color to v5 behavior

### DIFF
--- a/projects/core/src/button/button.element.scss
+++ b/projects/core/src/button/button.element.scss
@@ -223,7 +223,6 @@ cds-progress-circle {
 :host([disabled]),
 :host([disabled][action='outline']) {
   --background: #{$cds-alias-status-disabled-tint};
-  --color: #{$cds-alias-status-disabled-shade};
   --border-color: #{$cds-alias-status-disabled-tint};
   --box-shadow-color: #{$cds-alias-object-opacity-0};
 


### PR DESCRIPTION
reverts part of https://github.com/vmware/clarity/pull/6747/

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

This brings back the white color on grey disabled buttons from v5, following a conversation on slack.

<img width="278" alt="image" src="https://user-images.githubusercontent.com/9469374/172936747-0efd4023-5566-4092-b9d3-977f2d465434.png">

## What is the new behavior?

<img width="259" alt="image" src="https://user-images.githubusercontent.com/9469374/172936509-d4ebee9b-e8e6-4ae5-bcd4-7d7cb8715fa7.png">

It reverts part of https://github.com/vmware/clarity/pull/6747/

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
