### PR TITLE
fix(navigation): move navigation component back to beta

### DIFF
--- a/projects/core/src/navigation/navigation-group.element.ts
+++ b/projects/core/src/navigation/navigation-group.element.ts
@@ -43,6 +43,7 @@ export const CdsNavigationGroupTagName = 'cds-navigation-group';
  * </cds-navigation-group>
  * ```
  *
+ * @beta
  * @element cds-navigation-group
  * @event expandedChange - notify when the user has clicked the navigation expand/collapse button
  * @cssprop --animation-duration

--- a/projects/core/src/navigation/navigation-item.element.ts
+++ b/projects/core/src/navigation/navigation-item.element.ts
@@ -32,6 +32,7 @@ export const CdsNavigationItemTagName = 'cds-navigation-item';
  *  <cds-navigation-item><a href="/home">Home</cds-navigation-item>
  * ```
  *
+ * @beta
  * @element cds-navigation-item
  * @cssprop --color
  * @cssprop --font-size

--- a/projects/core/src/navigation/navigation.element.ts
+++ b/projects/core/src/navigation/navigation.element.ts
@@ -53,6 +53,7 @@ export const CdsNavigationTagName = 'cds-navigation';
  *  </cds-navigation>
  * ```
  *
+ * @beta
  * @element cds-navigation
  * @event expandedChange - notify when the user has clicked the navigation expand/collapse button
  * @cssprop --animation-duration

--- a/projects/core/src/navigation/navigation.stories.mdx
+++ b/projects/core/src/navigation/navigation.stories.mdx
@@ -4,6 +4,13 @@ import '@cds/core/navigation/register.js';
 
 <Meta title="Components/Navigation" />
 
+<cds-alert-group status="warning" cds-layout="m-b:lg">
+  <cds-alert>
+    This component or utility is offered as a preview. This means we are currently working on it and seeking feedback.
+    Please be aware that this component or utility may have breaking changes before we finish working on it.
+  </cds-alert>
+</cds-alert-group>
+
 # Navigation
 
 A sound navigation layout offers a high degree of discoverability and feedback, letting users know where they are at all


### PR DESCRIPTION
Moving it out of beta was an accident, this decision came out of discussion with Colin and the design team
