### PR TITLE
fix(spacing): use base 20 fallback spacing logic

### DIFF
--- a/projects/core/build/build.tokens.ts
+++ b/projects/core/build/build.tokens.ts
@@ -143,7 +143,10 @@ function tokenToSass(token: Token, fallback = false) {
   let fallbackValue = convertCSSValue(token);
 
   if (typeof token.value === 'number') {
-    fallbackValue = `${token.value / 16}rem`; // worst case scenario, fallback to base 16 if base 20 not set at root
+    // fallback to using the global base as a divisor,
+    //   which can be set even if global CSS isn't loaded
+    // worse case scenario, use base 20, Clarity's default
+    fallbackValue = `calc(${token.value} * (1rem / var(--cds-global-base, 20)))`;
   }
 
   if (token.config.raw) {


### PR DESCRIPTION
use 20 instead of 16 - 20 is the default described in the docs
allow for 16 to be set using --cds-global-base, even if the global css doesn't load

fixes vmware-clarity/ng-clarity#138

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

in v5, the fallback used a default base size of 20 - the default rem size for Clarity Core and NG. In v6, that changed to 16, the default rem size for browsers

Issue Number: vmware-clarity/ng-clarity#138

## What is the new behavior?

Change the fall back to 20, and also bring back the calculation logic that will attempt to use the --cds-global-base size first, if it exists. This means that even if the app doesn't import all of the global CSS, they can still change their base rem size use `--cds-global-base`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
