### PR TITLE
chore: record virtual page data for storybook analytics

### DIFF
--- a/projects/core/.storybook/manager-head.html
+++ b/projects/core/.storybook/manager-head.html
@@ -26,11 +26,16 @@
       m.parentNode.insertBefore(a, m);
     })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
     ga('create', 'UA-86120402-1', 'auto');
-    ga('send', 'pageview');
+    sendPageView();
     const pushState = window.history.pushState;
     window.history.pushState = function () {
       pushState.apply(window.history, arguments);
-      ga('send', 'pageview');
+      sendPageView();
     };
+
+    function sendPageView() {
+      ga('set', 'page', new URLSearchParams(window.location.search).get('path'));
+      ga('send', 'pageview');
+    }
   }
 </script>


### PR DESCRIPTION
Currently, storybook analytics doesn't specify which page is hit because storybook uses a query string to specify the page. This PR uses the virtual page feature of analytics and URLSearchParams to record accurate page views.