### PR TITLE
fix(spacing): use base 20 fallback spacing logic

### DIFF
--- a/projects/core/.storybook/preview.js
+++ b/projects/core/.storybook/preview.js
@@ -275,5 +275,4 @@ const dataThemeDecorator = (story, { globals }) => {
 export const decorators = [themeDecorator, dataThemeDecorator];
 
 // We have this here since storybook does not have a easy way to set the <html> element in demos
-// The token system generates a base 16px set of variables for apps that may not be able to easily set the base font to 125%
 document.body.setAttribute('cds-text', 'body');

--- a/projects/core/build/build.tokens.ts
+++ b/projects/core/build/build.tokens.ts
@@ -143,7 +143,10 @@ function tokenToSass(token: Token, fallback = false) {
   let fallbackValue = convertCSSValue(token);
 
   if (typeof token.value === 'number') {
-    fallbackValue = `${token.value / 16}rem`; // worst case scenario, fallback to base 16 if base 20 not set at root
+    // fallback to using the global base as a divisor,
+    //   which can be set even if global CSS isn't loaded
+    // worse case scenario, use base 20, Clarity's default
+    fallbackValue = `calc(${token.value} * (1rem / var(--cds-global-base, 20)))`;
   }
 
   if (token.config.raw) {

--- a/projects/core/src/index.performance.ts
+++ b/projects/core/src/index.performance.ts
@@ -13,7 +13,7 @@ describe('performance', () => {
     expect((await testBundleSize('@cds/core/list/list.min.css')).kb).toBeLessThan(0.5);
 
     // contained in @cds/core/global.min.css
-    expect((await testBundleSize('@cds/core/styles/module.layout.min.css')).kb).toBeLessThan(4.5);
+    expect((await testBundleSize('@cds/core/styles/module.layout.min.css')).kb).toBeLessThan(4.6);
     expect((await testBundleSize('@cds/core/styles/module.reset.min.css')).kb).toBeLessThan(0.5);
     expect((await testBundleSize('@cds/core/styles/module.tokens.min.css')).kb).toBeLessThan(2.5);
     expect((await testBundleSize('@cds/core/styles/module.typography.min.css')).kb).toBeLessThan(1.6);


### PR DESCRIPTION
use 20 instead of 16 - 20 is the default described in the docs
allow for 16 to be set using --cds-global-base, even if the global css doesn't load

fixes vmware-clarity/ng-clarity#138

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

in v5, the fallback used a default base size of 20 - the default rem size for Clarity Core and NG. In v6, that changed to 16, the default rem size for browsers

Issue Number: vmware-clarity/ng-clarity#138

## What is the new behavior?

Change the fall back to 20, and also bring back the calculation logic that will attempt to use the --cds-global-base size first, if it exists. This means that even if the app doesn't import all of the global CSS, they can still change their base rem size use `--cds-global-base`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
