### PR TITLE
fix(alert): fix alert close button positioning

### DIFF
--- a/projects/core/custom-elements.json
+++ b/projects/core/custom-elements.json
@@ -1227,6 +1227,14 @@
             },
             {
               "kind": "field",
+              "name": "iconSize",
+              "type": {
+                "text": "string"
+              },
+              "attribute": "iconSize"
+            },
+            {
+              "kind": "field",
               "name": "i18n"
             },
             {
@@ -1352,6 +1360,13 @@
                 "text": "string"
               },
               "fieldName": "action"
+            },
+            {
+              "name": "iconSize",
+              "type": {
+                "text": "string"
+              },
+              "fieldName": "iconSize"
             },
             {
               "name": "pressed",
@@ -1552,6 +1567,18 @@
             },
             {
               "kind": "field",
+              "name": "iconSize",
+              "type": {
+                "text": "string"
+              },
+              "attribute": "iconSize",
+              "inheritedFrom": {
+                "name": "CdsButtonAction",
+                "module": "button-action/button-action.element.js"
+              }
+            },
+            {
+              "kind": "field",
               "name": "i18n",
               "inheritedFrom": {
                 "name": "CdsButtonAction",
@@ -1677,6 +1704,17 @@
                 "text": "string"
               },
               "fieldName": "shape",
+              "inheritedFrom": {
+                "name": "CdsButtonAction",
+                "module": "button-action/button-action.element.js"
+              }
+            },
+            {
+              "name": "iconSize",
+              "type": {
+                "text": "string"
+              },
+              "fieldName": "iconSize",
               "inheritedFrom": {
                 "name": "CdsButtonAction",
                 "module": "button-action/button-action.element.js"
@@ -1854,6 +1892,18 @@
             },
             {
               "kind": "field",
+              "name": "iconSize",
+              "type": {
+                "text": "string"
+              },
+              "attribute": "iconSize",
+              "inheritedFrom": {
+                "name": "CdsButtonAction",
+                "module": "button-action/button-action.element.js"
+              }
+            },
+            {
+              "kind": "field",
               "name": "i18n",
               "inheritedFrom": {
                 "name": "CdsButtonAction",
@@ -1997,6 +2047,17 @@
                 "text": "string"
               },
               "fieldName": "action",
+              "inheritedFrom": {
+                "name": "CdsButtonAction",
+                "module": "button-action/button-action.element.js"
+              }
+            },
+            {
+              "name": "iconSize",
+              "type": {
+                "text": "string"
+              },
+              "fieldName": "iconSize",
               "inheritedFrom": {
                 "name": "CdsButtonAction",
                 "module": "button-action/button-action.element.js"
@@ -2667,6 +2728,18 @@
             },
             {
               "kind": "field",
+              "name": "iconSize",
+              "type": {
+                "text": "string"
+              },
+              "attribute": "iconSize",
+              "inheritedFrom": {
+                "name": "CdsButtonAction",
+                "module": "button-action/button-action.element.js"
+              }
+            },
+            {
+              "kind": "field",
               "name": "i18n",
               "inheritedFrom": {
                 "name": "CdsButtonAction",
@@ -2812,6 +2885,17 @@
                 "text": "string"
               },
               "fieldName": "action",
+              "inheritedFrom": {
+                "name": "CdsButtonAction",
+                "module": "button-action/button-action.element.js"
+              }
+            },
+            {
+              "name": "iconSize",
+              "type": {
+                "text": "string"
+              },
+              "fieldName": "iconSize",
               "inheritedFrom": {
                 "name": "CdsButtonAction",
                 "module": "button-action/button-action.element.js"
@@ -7838,6 +7922,18 @@
             },
             {
               "kind": "field",
+              "name": "iconSize",
+              "type": {
+                "text": "string"
+              },
+              "attribute": "iconSize",
+              "inheritedFrom": {
+                "name": "CdsButtonAction",
+                "module": "button-action/button-action.element.js"
+              }
+            },
+            {
+              "kind": "field",
               "name": "i18n",
               "inheritedFrom": {
                 "name": "CdsButtonAction",
@@ -7975,6 +8071,17 @@
                 "text": "string"
               },
               "fieldName": "shape",
+              "inheritedFrom": {
+                "name": "CdsButtonAction",
+                "module": "button-action/button-action.element.js"
+              }
+            },
+            {
+              "name": "iconSize",
+              "type": {
+                "text": "string"
+              },
+              "fieldName": "iconSize",
               "inheritedFrom": {
                 "name": "CdsButtonAction",
                 "module": "button-action/button-action.element.js"
@@ -36080,6 +36187,18 @@
             },
             {
               "kind": "field",
+              "name": "iconSize",
+              "type": {
+                "text": "string"
+              },
+              "attribute": "iconSize",
+              "inheritedFrom": {
+                "name": "CdsButtonAction",
+                "module": "button-action/button-action.element.js"
+              }
+            },
+            {
+              "kind": "field",
               "name": "i18n",
               "inheritedFrom": {
                 "name": "CdsButtonAction",
@@ -36218,6 +36337,17 @@
                 "text": "string"
               },
               "fieldName": "action",
+              "inheritedFrom": {
+                "name": "CdsButtonAction",
+                "module": "button-action/button-action.element.js"
+              }
+            },
+            {
+              "name": "iconSize",
+              "type": {
+                "text": "string"
+              },
+              "fieldName": "iconSize",
               "inheritedFrom": {
                 "name": "CdsButtonAction",
                 "module": "button-action/button-action.element.js"
@@ -50246,6 +50376,18 @@
             },
             {
               "kind": "field",
+              "name": "iconSize",
+              "type": {
+                "text": "string"
+              },
+              "attribute": "iconSize",
+              "inheritedFrom": {
+                "name": "CdsButtonAction",
+                "module": "button-action/button-action.element.js"
+              }
+            },
+            {
+              "kind": "field",
               "name": "i18n",
               "inheritedFrom": {
                 "name": "CdsButtonAction",
@@ -50371,6 +50513,17 @@
                 "text": "string"
               },
               "fieldName": "shape",
+              "inheritedFrom": {
+                "name": "CdsButtonAction",
+                "module": "button-action/button-action.element.js"
+              }
+            },
+            {
+              "name": "iconSize",
+              "type": {
+                "text": "string"
+              },
+              "fieldName": "iconSize",
               "inheritedFrom": {
                 "name": "CdsButtonAction",
                 "module": "button-action/button-action.element.js"

--- a/projects/core/src/alert/alert-group.stories.ts
+++ b/projects/core/src/alert/alert-group.stories.ts
@@ -47,6 +47,11 @@ export function alertGroup() {
         <cds-alert closable aria-label="This is an example info alert group">
           This example is a closable alert inside an alert group with a status of "info".
         </cds-alert>
+      </cds-alert-group>
+      <cds-alert-group status="info" aria-label="This is an example info alert group">
+        <cds-alert closable aria-label="This is an example info alert group">
+          This example is a closable alert inside an alert group with a status of "info".
+        </cds-alert>
         <cds-alert closable cds-i18n='{ "closeButtonAriaLabel": "close alert with a custom icon"}'>
           <cds-icon shape="node-group" aria-label="Custom icon of a node group" role="img"></cds-icon>
           This example is an alert a user may be able to close with a custom icon shape inside an alert group with a

--- a/projects/core/src/alert/alert.element.scss
+++ b/projects/core/src/alert/alert.element.scss
@@ -36,6 +36,11 @@ $lightweight-alert-line-height: $cds-global-typography-body-line-height;
   --color: var(--icon-color);
 }
 
+.alert-close-wrapper {
+  padding: var(--container-padding);
+  padding-bottom: 0;
+}
+
 cds-internal-close-button {
   --color: inherit;
 }

--- a/projects/core/src/alert/alert.element.ts
+++ b/projects/core/src/alert/alert.element.ts
@@ -252,13 +252,15 @@ export class CdsAlert extends LitElement {
           ? html`<span class="alert-spacer" cds-layout="align:stretch">&nbsp;</span>`
           : html``}
         ${this.type !== 'light' && this.closable
-          ? html`<slot name="close-button">
-              <cds-internal-close-button
-                icon-size="${this.type === 'banner' ? '20' : '16'}"
-                @click="${() => this.closableController.close(true)}"
-                aria-label="${this.i18n.closeButtonAriaLabel}"
-              ></cds-internal-close-button
-            ></slot>`
+          ? html`<span class="alert-close-wrapper"
+              ><slot name="close-button">
+                <cds-internal-close-button
+                  icon-size="${this.type === 'banner' ? '20' : '16'}"
+                  @click="${() => this.closableController.close(true)}"
+                  aria-label="${this.i18n.closeButtonAriaLabel}"
+                >
+                </cds-internal-close-button> </slot
+            ></span>`
           : html``}
       </div>
     `;

--- a/projects/core/src/button-action/button-action.element.spec.ts
+++ b/projects/core/src/button-action/button-action.element.spec.ts
@@ -47,4 +47,13 @@ describe('cds-button-action', () => {
     await componentIsStable(component);
     expect(component.hasAttribute('cds-button-action')).toBe(true);
   });
+
+  it('should update the size of the icon via the iconSize property', async () => {
+    await componentIsStable(component);
+    expect(component.offsetHeight).toEqual(16);
+
+    component.iconSize = '20';
+    await componentIsStable(component);
+    expect(component.offsetHeight).toEqual(20);
+  });
 });

--- a/projects/core/src/button-action/button-action.element.ts
+++ b/projects/core/src/button-action/button-action.element.ts
@@ -41,6 +41,8 @@ export class CdsButtonAction extends CdsBaseButton {
 
   @property({ type: String, reflect: true }) action: string;
 
+  @property({ type: String }) iconSize: string;
+
   @i18n() i18n = I18nService.keys.actions;
 
   @state({ type: Boolean, reflect: true, attribute: 'cds-button-action' }) protected cdsButtonAction = true;
@@ -53,6 +55,7 @@ export class CdsButtonAction extends CdsBaseButton {
         <slot
           ><cds-icon
             .shape=${this.shape ? this.shape : 'ellipsis-vertical'}
+            .size=${this.iconSize}
             ?solid=${this.pressed || this.expanded}
             inner-offset=${1}
           ></cds-icon


### PR DESCRIPTION
Closes #92

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The icon positioning of the close button is slightly off.

Issue Number: #92 

## What is the new behavior?

The close button now has the same padding on the top that the left icon and text does to they're all lined up. It  sets the padding on the bottom of the icon to 0, so as to not increase the height of the component.

There was also an icon-size attribute being set on the `cds-internal-close-button` component that wasn't being used, so I piped that through to the `cds-icon` underneath to fix the size of the icon

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
