### PR TITLE
feat: update homepage in package manifests (backport)

### DIFF
--- a/projects/adoption/package.lib.json
+++ b/projects/adoption/package.lib.json
@@ -1,7 +1,7 @@
 {
   "name": "@clr/eslint-plugin-clarity-adoption",
   "description": "A set of ESLint rules for Clarity Core adoption.",
-  "homepage": "https://clarity.design",
+  "homepage": "https://core.clarity.design",
   "keywords": ["clarity", "eslint-plugin", "eslint"],
   "repository": {
     "type": "git",

--- a/projects/angular/projects/cds-angular/package.json
+++ b/projects/angular/projects/cds-angular/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cds/angular",
   "description": "Core component modules for Clarity Angular",
-  "homepage": "https://clarity.design",
+  "homepage": "https://core.clarity.design",
   "keywords": [
     "angular",
     "design system",

--- a/projects/core/package.lib.json
+++ b/projects/core/package.lib.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "author": "clarity",
   "description": "Clarity Design System - common components, themes, and utilties",
-  "homepage": "https://clarity.design",
+  "homepage": "https://core.clarity.design",
   "customElements": "./custom-elements.json",
   "keywords": ["web component", "design system", "clarity", "ui"],
   "repository": {

--- a/projects/react/package.lib.json
+++ b/projects/react/package.lib.json
@@ -1,7 +1,7 @@
 {
   "name": "@cds/react",
   "description": "Core component modules for Clarity React",
-  "homepage": "https://clarity.design",
+  "homepage": "https://core.clarity.design",
   "keywords": ["react", "design system", "clarity", "ui"],
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is backport of #119.

## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Other: Package manifest update

## What is the current behavior?

npmjs.org links to https://clarity.design.

## What is the new behavior?

npmjs.org will link to https://core.clarity.design after this is released.