### PR TITLE
fix(modal): react - fix modal visibility when hidden="false"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ yarn-error.log
 testem.log
 /typings
 *.orig
+# sample react app creates this 
+**/.parcel-cache 
 
 # System files
 .DS_Store

--- a/projects/core/src/internal-components/overlay/overlay.element.scss
+++ b/projects/core/src/internal-components/overlay/overlay.element.scss
@@ -43,7 +43,9 @@
 }
 
 // we need the check against hidden='false' here because React is pushing string through instead of adding/removing the boolean attribute
-:host([hidden*='false']) {
+:host([hidden*='false']),
+:host([role='dialog'][hidden*='false']),
+[role='dialog'][hidden*='false'] {
   display: inline-flex !important;
 }
 

--- a/projects/core/src/internal/base/base.element.scss
+++ b/projects/core/src/internal/base/base.element.scss
@@ -60,6 +60,7 @@ slot {
 
 // https://developers.google.com/web/fundamentals/web-components/best-practices#add-a-:host-display-style-that-respects-the-hidden-attribute
 // we need the check against hidden='false' here because React is pushing string through instead of adding/removing the boolean attribute
+// https://github.com/lit/lit/issues/3053
 :host([hidden]),
 [hidden] {
   display: none !important;
@@ -76,6 +77,13 @@ slot {
   // safari https://www.tpgi.com/the-current-state-of-modal-dialog-accessibility/
   display: block !important;
   visibility: hidden !important;
+}
+
+[role='dialog'][hidden*='false'],
+[role='dialog'][hidden*='false'] > *,
+:host([role='dialog'][hidden*='false']),
+:host([role='dialog'][hidden*='false']) ::slotted(*) {
+  visibility: visible !important;
 }
 
 // normalize focus styles


### PR DESCRIPTION
fixes #122

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

`hidden={false}` on CdsModal renders as `hidden="false"`, which isn't really valid html, but it's an issue with react. The modal then doesn't render, because of css selectors for `[hidden]`

We had CSS to handle this case in v5, but some of the overlay/popover work in v6 overwrote the CSS

Issue Number: #122 

## What is the new behavior?

Increase CSS specificity of the visible styling for hidden="false"

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This could have been fixed alternatively with a React HOC that converts the hidden boolean value of false to undefined, which prevents the hidden attribute from being applied as expected. But in the interest of keeping the React code base as thin as possible, I put the fix into CSS that already existed for this use case.

I reported this to the Lit team on their slack in the hopes they'd come up with a fix in lit-labs/react, and this is something they're going to look into fixing more broadly. Reported here: https://github.com/lit/lit/issues/3053

Also, I tried to add a react unit tests for this, but there seemed to be a bug somewhere in  testing-library/dom or js-dom for this where the visibility property in CSS isn't cascaded/inherited correctly and checking for visibility returned visible, even when it's not.

