### PR TITLE
fix(button): restore disabled state set from outside when loading sta…

### DIFF
--- a/projects/core/custom-elements.json
+++ b/projects/core/custom-elements.json
@@ -1326,7 +1326,6 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
               "attribute": "disabled",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
@@ -1340,6 +1339,19 @@
                 "text": "string"
               },
               "attribute": "popup",
+              "inheritedFrom": {
+                "name": "CdsBaseButton",
+                "module": "internal/base/button.base.js"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "_disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "private",
+              "default": "false",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
                 "module": "internal/base/button.base.js"
@@ -1439,7 +1451,6 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
               "fieldName": "disabled",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
@@ -1665,7 +1676,6 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
               "attribute": "disabled",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
@@ -1679,6 +1689,19 @@
                 "text": "string"
               },
               "attribute": "popup",
+              "inheritedFrom": {
+                "name": "CdsBaseButton",
+                "module": "internal/base/button.base.js"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "_disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "private",
+              "default": "false",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
                 "module": "internal/base/button.base.js"
@@ -1791,7 +1814,6 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
               "fieldName": "disabled",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
@@ -2003,7 +2025,6 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
               "attribute": "disabled",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
@@ -2017,6 +2038,19 @@
                 "text": "string"
               },
               "attribute": "popup",
+              "inheritedFrom": {
+                "name": "CdsBaseButton",
+                "module": "internal/base/button.base.js"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "_disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "private",
+              "default": "false",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
                 "module": "internal/base/button.base.js"
@@ -2134,7 +2168,6 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
               "fieldName": "disabled",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
@@ -2305,7 +2338,6 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
               "attribute": "disabled",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
@@ -2319,6 +2351,19 @@
                 "text": "string"
               },
               "attribute": "popup",
+              "inheritedFrom": {
+                "name": "CdsBaseButton",
+                "module": "internal/base/button.base.js"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "_disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "private",
+              "default": "false",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
                 "module": "internal/base/button.base.js"
@@ -2403,7 +2448,6 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
               "fieldName": "disabled",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
@@ -2503,7 +2547,6 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
               "fieldName": "disabled",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
@@ -2613,7 +2656,6 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
               "attribute": "disabled",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
@@ -2627,6 +2669,19 @@
                 "text": "string"
               },
               "attribute": "popup",
+              "inheritedFrom": {
+                "name": "CdsBaseButton",
+                "module": "internal/base/button.base.js"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "_disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "private",
+              "default": "false",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
                 "module": "internal/base/button.base.js"
@@ -2839,7 +2894,6 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
               "attribute": "disabled",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
@@ -2853,6 +2907,19 @@
                 "text": "string"
               },
               "attribute": "popup",
+              "inheritedFrom": {
+                "name": "CdsBaseButton",
+                "module": "internal/base/button.base.js"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "_disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "private",
+              "default": "false",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
                 "module": "internal/base/button.base.js"
@@ -2972,7 +3039,6 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
               "fieldName": "disabled",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
@@ -3172,12 +3238,15 @@
             },
             {
               "kind": "field",
-              "name": "_disabled",
+              "name": "disabled",
               "type": {
                 "text": "boolean"
               },
-              "privacy": "private",
-              "default": "false"
+              "attribute": "disabled",
+              "inheritedFrom": {
+                "name": "CdsBaseButton",
+                "module": "internal/base/button.base.js"
+              }
             },
             {
               "kind": "method",
@@ -3198,8 +3267,17 @@
             },
             {
               "kind": "method",
-              "name": "enableButton",
+              "name": "restoreButton",
               "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "_disabledExternally",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "private",
+              "default": "false"
             },
             {
               "kind": "field",
@@ -3275,12 +3353,11 @@
             },
             {
               "kind": "field",
-              "name": "disabled",
+              "name": "popup",
               "type": {
-                "text": "boolean"
+                "text": "string"
               },
-              "default": "false",
-              "attribute": "disabled",
+              "attribute": "popup",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
                 "module": "internal/base/button.base.js"
@@ -3288,11 +3365,12 @@
             },
             {
               "kind": "field",
-              "name": "popup",
+              "name": "_disabled",
               "type": {
-                "text": "string"
+                "text": "boolean"
               },
-              "attribute": "popup",
+              "privacy": "private",
+              "default": "false",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
                 "module": "internal/base/button.base.js"
@@ -3343,6 +3421,17 @@
               },
               "description": "`default`: shows the content of the button\n- `loading`: disables the button and shows a spinner inside the button\n- `success`: disables the button and shows a check mark inside the button; auto-triggers to change back to DEFAULT state after 1000 ms\n- `error`: shows the content of the button (in the context of application, this state is usually entered from a LOADING state. the application should show appropriate error message)",
               "fieldName": "loadingState"
+            },
+            {
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "fieldName": "disabled",
+              "inheritedFrom": {
+                "name": "CdsBaseButton",
+                "module": "internal/base/button.base.js"
+              }
             },
             {
               "name": "pressed",
@@ -3405,18 +3494,6 @@
                 "text": "string"
               },
               "fieldName": "value",
-              "inheritedFrom": {
-                "name": "CdsBaseButton",
-                "module": "internal/base/button.base.js"
-              }
-            },
-            {
-              "name": "disabled",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "fieldName": "disabled",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
                 "module": "internal/base/button.base.js"
@@ -3568,15 +3645,14 @@
             },
             {
               "kind": "field",
-              "name": "_disabled",
+              "name": "disabled",
               "type": {
                 "text": "boolean"
               },
-              "privacy": "private",
-              "default": "false",
+              "attribute": "disabled",
               "inheritedFrom": {
-                "name": "CdsButton",
-                "module": "button/button.element.js"
+                "name": "CdsBaseButton",
+                "module": "internal/base/button.base.js"
               }
             },
             {
@@ -3606,8 +3682,21 @@
             },
             {
               "kind": "method",
-              "name": "enableButton",
+              "name": "restoreButton",
               "privacy": "private",
+              "inheritedFrom": {
+                "name": "CdsButton",
+                "module": "button/button.element.js"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "_disabledExternally",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "private",
+              "default": "false",
               "inheritedFrom": {
                 "name": "CdsButton",
                 "module": "button/button.element.js"
@@ -3687,12 +3776,11 @@
             },
             {
               "kind": "field",
-              "name": "disabled",
+              "name": "popup",
               "type": {
-                "text": "boolean"
+                "text": "string"
               },
-              "default": "false",
-              "attribute": "disabled",
+              "attribute": "popup",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
                 "module": "internal/base/button.base.js"
@@ -3700,11 +3788,12 @@
             },
             {
               "kind": "field",
-              "name": "popup",
+              "name": "_disabled",
               "type": {
-                "text": "string"
+                "text": "boolean"
               },
-              "attribute": "popup",
+              "privacy": "private",
+              "default": "false",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
                 "module": "internal/base/button.base.js"
@@ -3783,6 +3872,17 @@
               }
             },
             {
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "fieldName": "disabled",
+              "inheritedFrom": {
+                "name": "CdsBaseButton",
+                "module": "internal/base/button.base.js"
+              }
+            },
+            {
               "name": "pressed",
               "type": {
                 "text": "boolean"
@@ -3843,18 +3943,6 @@
                 "text": "string"
               },
               "fieldName": "value",
-              "inheritedFrom": {
-                "name": "CdsBaseButton",
-                "module": "internal/base/button.base.js"
-              }
-            },
-            {
-              "name": "disabled",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "fieldName": "disabled",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
                 "module": "internal/base/button.base.js"
@@ -8033,7 +8121,6 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
               "attribute": "disabled",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
@@ -8047,6 +8134,19 @@
                 "text": "string"
               },
               "attribute": "popup",
+              "inheritedFrom": {
+                "name": "CdsBaseButton",
+                "module": "internal/base/button.base.js"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "_disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "private",
+              "default": "false",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
                 "module": "internal/base/button.base.js"
@@ -8158,7 +8258,6 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
               "fieldName": "disabled",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
@@ -36298,7 +36397,6 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
               "attribute": "disabled",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
@@ -36312,6 +36410,19 @@
                 "text": "string"
               },
               "attribute": "popup",
+              "inheritedFrom": {
+                "name": "CdsBaseButton",
+                "module": "internal/base/button.base.js"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "_disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "private",
+              "default": "false",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
                 "module": "internal/base/button.base.js"
@@ -36424,7 +36535,6 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
               "fieldName": "disabled",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
@@ -37933,7 +38043,6 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
               "attribute": "disabled"
             },
             {
@@ -37943,6 +38052,15 @@
                 "text": "string"
               },
               "attribute": "popup"
+            },
+            {
+              "kind": "field",
+              "name": "_disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "private",
+              "default": "false"
             }
           ],
           "attributes": [
@@ -37993,7 +38111,6 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
               "fieldName": "disabled"
             },
             {
@@ -50355,7 +50472,6 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
               "attribute": "disabled",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
@@ -50492,6 +50608,19 @@
                 "name": "CdsBaseButton",
                 "module": "internal/base/button.base.js"
               }
+            },
+            {
+              "kind": "field",
+              "name": "_disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "private",
+              "default": "false",
+              "inheritedFrom": {
+                "name": "CdsBaseButton",
+                "module": "internal/base/button.base.js"
+              }
             }
           ],
           "attributes": [
@@ -50600,7 +50729,6 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
               "fieldName": "disabled",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
@@ -57347,7 +57475,6 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
               "attribute": "disabled",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
@@ -57361,6 +57488,19 @@
                 "text": "string"
               },
               "attribute": "popup",
+              "inheritedFrom": {
+                "name": "CdsBaseButton",
+                "module": "internal/base/button.base.js"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "_disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "private",
+              "default": "false",
               "inheritedFrom": {
                 "name": "CdsBaseButton",
                 "module": "internal/base/button.base.js"
@@ -57465,7 +57605,6 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "false",
               "fieldName": "disabled",
               "inheritedFrom": {
                 "name": "CdsBaseButton",

--- a/projects/core/src/button/button.element.spec.ts
+++ b/projects/core/src/button/button.element.spec.ts
@@ -279,7 +279,7 @@ describe('button element', () => {
       expect(component.disabled).not.toBeTruthy();
     });
 
-    it('should stay disabled when loadingState changes to default', async () => {
+    it('should stay disabled when loadingState changes back to default', async () => {
       await componentIsStable(component);
       component.disabled = true;
       component.loadingState = ClrLoadingState.default;
@@ -290,6 +290,25 @@ describe('button element', () => {
       expect(component.disabled).toBeTruthy();
 
       component.loadingState = ClrLoadingState.success;
+      await componentIsStable(component);
+      expect(component.disabled).toBeTruthy();
+
+      component.loadingState = ClrLoadingState.default;
+      await componentIsStable(component);
+      expect(component.disabled).toBeTruthy();
+    });
+
+    it('should return to disabled state when set in non-default loadingState status', async () => {
+      await componentIsStable(component);
+      component.loadingState = ClrLoadingState.default;
+      await componentIsStable(component);
+
+      component.loadingState = ClrLoadingState.loading;
+      await componentIsStable(component);
+      expect(component.disabled).toBeTruthy();
+
+      component.loadingState = ClrLoadingState.success;
+      component.disabled = true;
       await componentIsStable(component);
       expect(component.disabled).toBeTruthy();
 
@@ -309,6 +328,25 @@ describe('button element', () => {
       component.size = 'sm';
       await componentIsStable(component);
       expect(component.shadowRoot.querySelector<any>('cds-progress-circle').size).toBe('12');
+    });
+
+    it('should not have hardcoded width on initial render', async () => {
+      // the width is only hardcoded when switching from default (with button text) to a loading status (with icon)
+      const testElement2 = await createTestElement(html`
+        <form>
+          <cds-button loading-state="loading">
+            <span>${placeholderText}</span>
+          </cds-button>
+        </form>
+      `);
+
+      const component2 = testElement2.querySelector<CdsButton>('cds-button');
+      await componentIsStable(component2);
+
+      expect(component2.style.width).toEqual('');
+      expect(component2.getBoundingClientRect().width).toBeGreaterThan(12);
+
+      removeTestElement(testElement2);
     });
   });
 });

--- a/projects/core/src/internal/base/button.base.ts
+++ b/projects/core/src/internal/base/button.base.ts
@@ -39,7 +39,18 @@ export class CdsBaseButton extends LitElement {
 
   @property({ type: String }) value: string;
 
-  @property({ type: Boolean }) disabled = false;
+  @property({ type: Boolean })
+  get disabled(): boolean {
+    return this._disabled;
+  }
+
+  set disabled(value: boolean) {
+    const oldValue = this._disabled;
+    this._disabled = value;
+    this.requestUpdate('disabled', oldValue);
+  }
 
   @property({ type: String }) popup: string;
+
+  private _disabled = false;
 }

--- a/projects/react/src/button/__snapshots__/index.test.tsx.snap
+++ b/projects/react/src/button/__snapshots__/index.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`CdsButton snapshot 1`] = `
     danger
   </cds-button>
   <cds-button
+    disabled="true"
     tabindex="0"
   >
     disabled

--- a/projects/react/src/button/index.test.tsx
+++ b/projects/react/src/button/index.test.tsx
@@ -17,7 +17,9 @@ describe('CdsButton', () => {
 
     expect(await screen.findByRole('button', { name: 'primary' })).toHaveAttribute('status', 'primary');
     expect(await screen.findByRole('button', { name: 'success' })).toHaveAttribute('status', 'success');
-    expect(await screen.findByRole('button', { name: 'disabled' })).toHaveAttribute('disabled', '');
+    // There's a lit issue that is resulting in this being 'true' instead of ''
+    // https://github.com/lit/lit/issues/2799#issuecomment-1203178300
+    expect(await screen.findByRole('button', { name: 'disabled' })).toHaveAttribute('disabled', 'true');
   });
 
   it('snapshot', () => {

--- a/projects/react/src/pagination/__snapshots__/index.test.tsx.snap
+++ b/projects/react/src/pagination/__snapshots__/index.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`CdsPagination snapshot 1`] = `
     <style />
     <cds-pagination-button
       aria-label="go to first"
+      disabled="true"
       tabindex="0"
     />
     <cds-pagination-button


### PR DESCRIPTION
…te changes to default

Signed-off-by: EndzeitBegins <16666115+EndzeitBegins@users.noreply.github.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #129

## What is the new behavior?

When changing to the `loadingState` to default the `disabled` value set from outside is restored, whether is was set before or while the `loadingState` was non-default.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

My solution includes replacing the field `disabled` in `CdsBaseButton` with a corresponding getter and setter in order to override its behavior in `CdsButton`. This in turn adds a private field `_disabled` to `CdsBaseButton`. To avoid collisions I renamed `_disabled` to `_disabled_from_outside` in `CdsButton`. 
According to `npm run public-api:check` this results in changes to the "public" API, even though only private fields were added / renamed and the field `disabled` replaced with getter / setter.