### PR TITLE
fix(tag): remove hover bg color change when disabled

### DIFF
--- a/projects/core/src/tag/tag.element.scss
+++ b/projects/core/src/tag/tag.element.scss
@@ -106,7 +106,7 @@ cds-icon[shape='times'] {
 :host([color]) {
   --background: #{$cds-alias-object-opacity-0};
 
-  :hover {
+  &:host(:not([disabled])) :hover {
     --background: #{$cds-alias-status-neutral-tint};
   }
 }

--- a/projects/core/src/tag/tag.stories.ts
+++ b/projects/core/src/tag/tag.stories.ts
@@ -157,6 +157,23 @@ export function clickable() {
           <cds-badge aria-label="notification 12" status="danger">12</cds-badge></cds-tag
         >
       </div>
+      <div cds-layout="horizontal gap:sm">
+        <cds-tag status="info" disabled
+          ><cds-icon shape="info-standard" role="img" alt="info"></cds-icon>Disabled</cds-tag
+        >
+        <cds-tag status="info" disabled
+          ><cds-icon shape="info-standard" role="img" alt="info"></cds-icon>Info Disabled</cds-tag
+        >
+        <cds-tag status="success" disabled
+          ><cds-icon shape="info-standard" role="img" alt="info"></cds-icon>Success Disabled</cds-tag
+        >
+        <cds-tag status="warning" disabled
+          ><cds-icon shape="info-standard" role="img" alt="info"></cds-icon>Warning Disabled</cds-tag
+        >
+        <cds-tag status="danger" disabled
+          ><cds-icon shape="info-standard" role="img" alt="info"></cds-icon>Danger Disabled</cds-tag
+        >
+      </div>
       <br />
       <div cds-layout="horizontal gap:sm">
         <cds-tag color="purple">Purple</cds-tag>
@@ -195,6 +212,13 @@ export function clickable() {
           <cds-icon shape="info-standard" role="img" alt="info"></cds-icon>Light Blue
           <cds-badge aria-label="notification 1">1</cds-badge>
         </cds-tag>
+      </div>
+      <div cds-layout="horizontal gap:sm">
+        <cds-tag disabled color="gray">Default <cds-badge aria-label="notification 1">1</cds-badge></cds-tag>
+        <cds-tag disabled color="purple">Purple <cds-badge aria-label="notification 2">2</cds-badge></cds-tag>
+        <cds-tag disabled color="blue">Blue <cds-badge aria-label="notification 3">3</cds-badge></cds-tag>
+        <cds-tag disabled color="orange">Orange <cds-badge aria-label="notification 12">12</cds-badge></cds-tag>
+        <cds-tag disabled color="light-blue">Light Blue <cds-badge aria-label="notification 15">15</cds-badge></cds-tag>
       </div>
     </div>
   `;


### PR DESCRIPTION
fixes #134

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When hovering over a disabled clickable tag, the background color still changes

Issue Number: #134 

## What is the new behavior?

The background color no longer changes on hover, when disabled

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
