### PR TITLE
fix(alert): prevent content from overflowing alert

### DIFF
--- a/projects/core/src/alert/alert.element.scss
+++ b/projects/core/src/alert/alert.element.scss
@@ -50,6 +50,7 @@ cds-internal-close-button {
   display: flex;
   min-height: #{$cds-global-space-6};
   padding: var(--container-padding);
+  min-width: 0;
 }
 
 .alert-icon-wrapper {
@@ -68,6 +69,10 @@ cds-internal-close-button {
   font-weight: var(--font-weight);
   letter-spacing: var(--letter-spacing);
   line-height: $lightweight-alert-line-height;
+}
+
+.alert-content {
+  min-width: 0;
 }
 
 ::slotted(cds-alert-actions) {

--- a/projects/core/src/alert/alert.element.spec.ts
+++ b/projects/core/src/alert/alert.element.spec.ts
@@ -55,6 +55,33 @@ describe('Alert element – ', () => {
     });
   });
 
+  describe('layout:', () => {
+    beforeEach(async () => {
+      testElement = await createTestElement(html`
+        <cds-alert-group status="info" style="width: 200px">
+          <cds-alert>
+            <pre style="overflow-x: auto">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
+              sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            </pre
+            >
+          </cds-alert>
+        </cds-alert-group>
+      `);
+      component = testElement.querySelector<CdsAlert>('cds-alert');
+    });
+
+    afterEach(() => {
+      removeTestElement(testElement);
+    });
+
+    it('should not let content overflow alert', async () => {
+      await componentIsStable(component);
+      const content = component.querySelector('pre');
+      expect(content.getBoundingClientRect().width).toBeLessThan(component.getBoundingClientRect().width);
+    });
+  });
+
   describe('custom icons: ', () => {
     let customComponent: CdsAlert;
 


### PR DESCRIPTION
- flexbox has some quirks with overflow
- setting min-width: 0 prevents the content from overflowing

fixes #137

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Content with overflow-x: auto that would otherwise render a scrollbar in a small container are instead overflowing the alert

Issue Number: #137 

## What is the new behavior?

add min-width: 0 to allow content to be smaller than the implied width: https://css-tricks.com/flexbox-truncated-text/

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
