### PR TITLE
fix: remove margin when cds-text=body is applied to body tag

### DIFF
--- a/projects/core/src/styles/typography/_typography.scss
+++ b/projects/core/src/styles/typography/_typography.scss
@@ -131,6 +131,11 @@
   line-height: $cds-global-typography-body-line-height;
 }
 
+// remove extra margin on the body tag to avoid an unnecessary scrollbar
+body[cds-text*='body'] {
+  @include remove-line-height-erasers;
+}
+
 [cds-text*='message'] {
   $lh-gap: getLineHeightGap(
     $cds-global-typography-message-line-height-static,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #143 

## What is the new behavior?

The line height eraser is removed on the body tag

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
