### PR TITLE
fix: upgrade lit-labs/react version

### DIFF
--- a/projects/react/package.json
+++ b/projects/react/package.json
@@ -17,7 +17,7 @@
     "@babel/core": "7.12.0",
     "@babel/preset-env": "7.12.0",
     "@cds/core": "file:./../core/dist/lib",
-    "@lit-labs/react": "^1.0.1",
+    "@lit-labs/react": "^1.0.8",
     "@testing-library/dom": "^8.11.3",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.2",

--- a/projects/react/src/button/__snapshots__/index.test.tsx.snap
+++ b/projects/react/src/button/__snapshots__/index.test.tsx.snap
@@ -18,7 +18,6 @@ exports[`CdsButton snapshot 1`] = `
     danger
   </cds-button>
   <cds-button
-    disabled="true"
     tabindex="0"
   >
     disabled

--- a/projects/react/src/button/index.test.tsx
+++ b/projects/react/src/button/index.test.tsx
@@ -17,9 +17,8 @@ describe('CdsButton', () => {
 
     expect(await screen.findByRole('button', { name: 'primary' })).toHaveAttribute('status', 'primary');
     expect(await screen.findByRole('button', { name: 'success' })).toHaveAttribute('status', 'success');
-    // There's a lit issue that is resulting in this being 'true' instead of ''
-    // https://github.com/lit/lit/issues/2799#issuecomment-1203178300
-    expect(await screen.findByRole('button', { name: 'disabled' })).toHaveAttribute('disabled', 'true');
+    expect(await screen.findByRole('button', { name: 'disabled' })).toBeDisabled();
+    expect(await screen.findByRole('button', { name: 'disabled' })).toHaveAttribute('disabled', '');
   });
 
   it('snapshot', () => {

--- a/projects/react/src/date/__snapshots__/index.test.tsx.snap
+++ b/projects/react/src/date/__snapshots__/index.test.tsx.snap
@@ -5,7 +5,6 @@ exports[`CdsDate snapshot 1`] = `
   <cds-date
     cds-control=""
     control-width="shrink"
-    layout="horizontal"
   >
     <style />
     <label

--- a/projects/react/src/file/__snapshots__/index.test.tsx.snap
+++ b/projects/react/src/file/__snapshots__/index.test.tsx.snap
@@ -4,7 +4,6 @@ exports[`CdsFile snapshot 1`] = `
 <div>
   <cds-file
     cds-control=""
-    layout="vertical"
   >
     <label>
       label

--- a/projects/react/src/forms/__snapshots__/index.test.tsx.snap
+++ b/projects/react/src/forms/__snapshots__/index.test.tsx.snap
@@ -7,7 +7,6 @@ exports[`CdsControl snapshot 1`] = `
   >
     <cds-control
       cds-control=""
-      layout="compact"
     >
       <label>
         label
@@ -23,7 +22,6 @@ exports[`CdsControl snapshot 1`] = `
     </cds-control>
     <cds-control
       cds-control=""
-      layout="compact"
     >
       <label>
         label
@@ -39,7 +37,6 @@ exports[`CdsControl snapshot 1`] = `
     </cds-control>
     <cds-control
       cds-control=""
-      layout="compact"
     >
       <label>
         label

--- a/projects/react/src/icon/__snapshots__/index.test.tsx.snap
+++ b/projects/react/src/icon/__snapshots__/index.test.tsx.snap
@@ -2,25 +2,10 @@
 
 exports[`CdsIcon snapshot 1`] = `
 <div>
-  <cds-icon
-    shape="user"
-    size="lg"
-  />
-  <cds-icon
-    shape="user"
-    size="lg"
-  />
-  <cds-icon
-    shape="user"
-    size="lg"
-  />
-  <cds-icon
-    shape="user"
-    size="lg"
-  />
-  <cds-icon
-    shape="user"
-    size="lg"
-  />
+  <cds-icon />
+  <cds-icon />
+  <cds-icon />
+  <cds-icon />
+  <cds-icon />
 </div>
 `;

--- a/projects/react/src/input/__snapshots__/index.test.tsx.snap
+++ b/projects/react/src/input/__snapshots__/index.test.tsx.snap
@@ -8,7 +8,6 @@ exports[`CdsInput snapshot 1`] = `
   >
     <cds-input
       cds-control=""
-      layout="vertical"
     >
       <label>
         label
@@ -19,7 +18,6 @@ exports[`CdsInput snapshot 1`] = `
     </cds-input>
     <cds-input
       cds-control=""
-      layout="vertical"
     >
       <label>
         disabled

--- a/projects/react/src/pagination/__snapshots__/index.test.tsx.snap
+++ b/projects/react/src/pagination/__snapshots__/index.test.tsx.snap
@@ -8,7 +8,6 @@ exports[`CdsPagination snapshot 1`] = `
     <style />
     <cds-pagination-button
       aria-label="go to first"
-      disabled="true"
       tabindex="0"
     />
     <cds-pagination-button

--- a/projects/react/src/pagination/index.test.tsx
+++ b/projects/react/src/pagination/index.test.tsx
@@ -10,11 +10,12 @@ describe('CdsPagination', () => {
         <CdsPaginationButton aria-label="go to previous" action="prev" disabled></CdsPaginationButton>
         <span aria-label="current page">1 / 3</span>
         <CdsPaginationButton aria-label="go to next" action="next"></CdsPaginationButton>
-        <CdsPaginationButton aria-label="go to last" action="last"></CdsPaginationButton>
+        <CdsPaginationButton aria-label="go to last" action="last" disabled={false}></CdsPaginationButton>
       </CdsPagination>
     );
     expect(document.querySelector('cds-pagination')).toBeInTheDocument();
     expect(await screen.findByRole('button', { name: /go to first/i })).toBeDisabled();
+    expect(await screen.findByRole('button', { name: /go to next/i })).not.toBeDisabled();
     expect(await screen.findByRole('button', { name: /go to last/i })).not.toBeDisabled();
     expect(await screen.findByLabelText('current page')).toHaveTextContent(/1 \/ 3/i);
   });
@@ -23,7 +24,7 @@ describe('CdsPagination', () => {
     const { container } = render(
       <CdsPagination aria-label="pagination">
         <CdsPaginationButton aria-label="go to first" action="prev" disabled></CdsPaginationButton>
-        <CdsPaginationButton aria-label="go to next" action="next"></CdsPaginationButton>
+        <CdsPaginationButton aria-label="go to next" action="next" disabled={false}></CdsPaginationButton>
       </CdsPagination>
     );
     expect(container).toMatchSnapshot();

--- a/projects/react/src/password/__snapshots__/index.test.tsx.snap
+++ b/projects/react/src/password/__snapshots__/index.test.tsx.snap
@@ -4,7 +4,6 @@ exports[`CdsPassword snapshot 1`] = `
 <div>
   <cds-password
     cds-control=""
-    layout="vertical"
   >
     <label>
       label

--- a/projects/react/src/range/__snapshots__/index.test.tsx.snap
+++ b/projects/react/src/range/__snapshots__/index.test.tsx.snap
@@ -5,7 +5,6 @@ exports[`CdsRange snapshot 1`] = `
   <cds-form-group>
     <cds-range
       cds-control=""
-      layout="horizontal"
     >
       <style />
       <label>
@@ -22,7 +21,6 @@ exports[`CdsRange snapshot 1`] = `
     </cds-range>
     <cds-range
       cds-control=""
-      layout="horizontal"
     >
       <style />
       <label>
@@ -40,7 +38,6 @@ exports[`CdsRange snapshot 1`] = `
     </cds-range>
     <cds-range
       cds-control=""
-      layout="horizontal"
     >
       <style />
       <label>
@@ -57,7 +54,6 @@ exports[`CdsRange snapshot 1`] = `
     </cds-range>
     <cds-range
       cds-control=""
-      layout="horizontal"
     >
       <style />
       <label>

--- a/projects/react/src/search/__snapshots__/index.test.tsx.snap
+++ b/projects/react/src/search/__snapshots__/index.test.tsx.snap
@@ -62,7 +62,6 @@ exports[`CdsSearch snapshot 1`] = `
     <cds-form-group>
       <cds-search
         cds-control=""
-        layout="horizontal"
       >
         <style />
         <label>
@@ -79,7 +78,6 @@ exports[`CdsSearch snapshot 1`] = `
       </cds-search>
       <cds-search
         cds-control=""
-        layout="horizontal"
       >
         <style />
         <label>
@@ -96,7 +94,6 @@ exports[`CdsSearch snapshot 1`] = `
       </cds-search>
       <cds-search
         cds-control=""
-        layout="horizontal"
       >
         <style />
         <label>
@@ -118,7 +115,6 @@ exports[`CdsSearch snapshot 1`] = `
     <cds-form-group>
       <cds-search
         cds-control=""
-        layout="compact"
       >
         <style />
         <label>
@@ -135,7 +131,6 @@ exports[`CdsSearch snapshot 1`] = `
       </cds-search>
       <cds-search
         cds-control=""
-        layout="compact"
       >
         <style />
         <label>
@@ -152,7 +147,6 @@ exports[`CdsSearch snapshot 1`] = `
       </cds-search>
       <cds-search
         cds-control=""
-        layout="compact"
       >
         <style />
         <label>

--- a/projects/react/src/textarea/__snapshots__/index.test.tsx.snap
+++ b/projects/react/src/textarea/__snapshots__/index.test.tsx.snap
@@ -9,7 +9,6 @@ exports[`CdsTextarea snapshot 1`] = `
     <cds-form-group>
       <cds-textarea
         cds-control=""
-        layout="vertical"
       >
         <label>
           label
@@ -23,7 +22,6 @@ exports[`CdsTextarea snapshot 1`] = `
       </cds-textarea>
       <cds-textarea
         cds-control=""
-        layout="vertical"
       >
         <label>
           error status
@@ -37,7 +35,6 @@ exports[`CdsTextarea snapshot 1`] = `
       </cds-textarea>
       <cds-textarea
         cds-control=""
-        layout="vertical"
       >
         <label>
           success status
@@ -56,7 +53,6 @@ exports[`CdsTextarea snapshot 1`] = `
     <cds-form-group>
       <cds-textarea
         cds-control=""
-        layout="horizontal"
       >
         <label>
           label
@@ -70,7 +66,6 @@ exports[`CdsTextarea snapshot 1`] = `
       </cds-textarea>
       <cds-textarea
         cds-control=""
-        layout="horizontal"
       >
         <label>
           error status
@@ -84,7 +79,6 @@ exports[`CdsTextarea snapshot 1`] = `
       </cds-textarea>
       <cds-textarea
         cds-control=""
-        layout="horizontal"
       >
         <label>
           success status


### PR DESCRIPTION
- adopts the fix for boolean getters and setters from https://github.com/lit/lit/issues/2799#issuecomment-1203178300
- fixes an issue introduced in PR #130 where cds-pagination-button was getting disabled="false" rendered

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Upgrades to the latest version of lit-labs/react, and includes a fix for #151 

## What is the new behavior?

Fixes property accessors (props with get/set) in react. Adds a unit test for the disabled="false" issue

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
