### PR TITLE
fix(navigation): sync state with newly added nav items

### DIFF
--- a/projects/core/custom-elements.json
+++ b/projects/core/custom-elements.json
@@ -49999,17 +49999,6 @@
               "description": "query for all groups (including any nested groups), used ot pass state down"
             },
             {
-              "kind": "method",
-              "name": "toggle",
-              "privacy": "private"
-            },
-            {
-              "kind": "field",
-              "name": "currentActiveItem",
-              "privacy": "private",
-              "readonly": true
-            },
-            {
               "kind": "field",
               "name": "endTemplate",
               "privacy": "protected",
@@ -50022,6 +50011,14 @@
               "readonly": true
             },
             {
+              "kind": "method",
+              "name": "addStartEventListener"
+            },
+            {
+              "kind": "method",
+              "name": "updateChildrenProps"
+            },
+            {
               "kind": "field",
               "name": "visibleChildren",
               "type": {
@@ -50032,7 +50029,14 @@
             },
             {
               "kind": "method",
-              "name": "addStartEventListener"
+              "name": "toggle",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "currentActiveItem",
+              "privacy": "private",
+              "readonly": true
             },
             {
               "kind": "method",
@@ -50085,10 +50089,6 @@
                   }
                 }
               ]
-            },
-            {
-              "kind": "method",
-              "name": "updateChildrenProps"
             }
           ],
           "events": [

--- a/projects/core/custom-elements.json
+++ b/projects/core/custom-elements.json
@@ -50012,7 +50012,11 @@
             },
             {
               "kind": "method",
-              "name": "addStartEventListener"
+              "name": "onStartItemSlotChange"
+            },
+            {
+              "kind": "method",
+              "name": "onItemSlotChange"
             },
             {
               "kind": "method",

--- a/projects/core/src/navigation/navigation.element.spec.ts
+++ b/projects/core/src/navigation/navigation.element.spec.ts
@@ -125,11 +125,23 @@ describe('cds-navigation', () => {
       itemRefs.forEach(item => {
         expect(item.expanded).toBe(component.expanded);
       });
+
+      component.expanded = true;
+      await componentIsStable(component);
+      itemRefs.forEach(item => {
+        expect(item.expanded).toBe(component.expanded);
+      });
     });
 
     it('to navigationStartRefs', async () => {
       await componentIsStable(component);
       const startRefs = component.querySelectorAll<CdsNavigationStart>('cds-navigation-start');
+      startRefs.forEach(start => {
+        expect(start.expandedRoot).toBe(component.expandedRoot);
+      });
+
+      component.expanded = true;
+      await componentIsStable(component);
       startRefs.forEach(start => {
         expect(start.expandedRoot).toBe(component.expandedRoot);
       });
@@ -139,6 +151,10 @@ describe('cds-navigation', () => {
       await componentIsStable(component);
       const rootStart = component.querySelector<CdsNavigationStart>(':scope > cds-navigation-start');
       expect(rootStart.expanded).toBe(component.expanded);
+
+      component.expanded = true;
+      await componentIsStable(component);
+      expect(rootStart.expanded).toBe(component.expanded);
     });
 
     it('to rootNavigationItems', async () => {
@@ -147,6 +163,28 @@ describe('cds-navigation', () => {
       rootItems.forEach(item => {
         expect(item.expanded).toBe(component.expanded);
       });
+
+      component.expanded = true;
+      await componentIsStable(component);
+      rootItems.forEach(item => {
+        expect(item.expanded).toBe(component.expanded);
+      });
+    });
+
+    it('to new navigation items', async () => {
+      component.expanded = true;
+      await componentIsStable(component);
+
+      const navItem = document.createElement('cds-navigation-item');
+      navItem.id = 'my-new-nav-item';
+      navItem.innerHTML = '<a href="#">My New Nav Item</a>';
+
+      component.appendChild(navItem);
+
+      await componentIsStable(component);
+
+      expect(navItem.expanded).toBe(component.expanded);
+      expect(navItem.tabIndex).toBe(-1);
     });
   });
 });

--- a/projects/core/src/navigation/navigation.element.ts
+++ b/projects/core/src/navigation/navigation.element.ts
@@ -181,7 +181,7 @@ export class CdsNavigation extends LitElement {
     return this.navigationEnd
       ? html`
           <div class="navigation-end" cds-layout="vertical align:horizontal-stretch">
-            <slot name="cds-navigation-end"></slot>
+            <slot name="cds-navigation-end" @slotchange=${this.onItemSlotChange}></slot>
           </div>
         `
       : '';
@@ -193,7 +193,7 @@ export class CdsNavigation extends LitElement {
     this.rootNavigationStart
       ? (returnHTML = html`
           <div class="navigation-start" cds-layout="vertical align:horizontal-stretch">
-            <slot @slotchange="${() => this.addStartEventListener()}" name="navigation-start"></slot>
+            <slot @slotchange="${() => this.onStartItemSlotChange()}" name="navigation-start"></slot>
             <cds-divider class="start-divider"></cds-divider>
           </div>
         `)
@@ -209,7 +209,7 @@ export class CdsNavigation extends LitElement {
       <nav class="navigation-body-wrapper">
         <div .ariaActiveDescendant=${this.ariaActiveDescendant} tabindex="0" id="item-container">
           <div class="navigation-body" cds-layout="vertical wrap:none align:horizontal-stretch">
-            <slot></slot>
+            <slot @slotchange=${this.onItemSlotChange}></slot>
           </div>
         </div>
       </nav>
@@ -234,10 +234,6 @@ export class CdsNavigation extends LitElement {
 
   firstUpdated(props: PropertyValues<this>) {
     super.firstUpdated(props);
-    // set all visible navigation elements to tabindex = -1
-    this.allNavigationElements.forEach(item => {
-      setAttributes(item, ['tabindex', '-1']);
-    });
 
     const itemWrapper = this.shadowRoot?.querySelector('#item-container');
     itemWrapper?.addEventListener('focus', this.initItemKeys.bind(this));
@@ -255,12 +251,23 @@ export class CdsNavigation extends LitElement {
     this.updateChildrenProps();
   }
 
-  addStartEventListener() {
+  onStartItemSlotChange() {
+    this.onItemSlotChange();
+
     // This is controlled by the slotchange event on the navigation-start slot
     // Make sure we reattach the click handler for toggle if consumer changes the start element (e.g *ngIf)
     if (this.rootNavigationStart) {
       this.rootNavigationStart.addEventListener('click', this.toggle.bind(this));
     }
+  }
+
+  onItemSlotChange() {
+    this.updateChildrenProps();
+
+    // set all visible navigation elements to tabindex = -1
+    this.allNavigationElements.forEach(item => {
+      setAttributes(item, ['tabindex', '-1']);
+    });
   }
 
   updateChildrenProps() {


### PR DESCRIPTION
fixes  #155 #82

- previously only nav items in the initial render were synced with the top level expanded state
- add onslotchange to check for that
- move tabindex logic to slot change handler as well
- reorder component functions to match best practices
- update unit tests to check syncing after component updates

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Previously, expanded state was only shared with nav items on the initial render, or when the parent navigation component had updates. Asynchronously added nav items were treated as collapses, instead of having their parent state synced

Issue Number: #155 #82

## What is the new behavior?

the slotchange event was added to the slot to detect when new items are added

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
