### PR TITLE
fix(range): update track width when value is changed programmatically

### DIFF
--- a/projects/core/custom-elements.json
+++ b/projects/core/custom-elements.json
@@ -53135,7 +53135,16 @@
             {
               "kind": "method",
               "name": "setTrackWidth",
-              "privacy": "private"
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "val",
+                  "optional": true,
+                  "type": {
+                    "text": "number"
+                  }
+                }
+              ]
             },
             {
               "kind": "field",

--- a/projects/core/src/range/range.element.spec.ts
+++ b/projects/core/src/range/range.element.spec.ts
@@ -47,4 +47,14 @@ describe('cds-range', () => {
     await componentIsStable(component);
     expect(getCssPropertyValue('--track-width', component)).toBe('77%');
   });
+
+  it('should update the track width style when the value is changed programmatically (no input event)', async () => {
+    await componentIsStable(component);
+    expect(getCssPropertyValue('--track-width', component)).toBe('50%');
+
+    component.inputControl.value = '75';
+
+    await componentIsStable(component);
+    expect(getCssPropertyValue('--track-width', component)).toBe('75%');
+  });
 });


### PR DESCRIPTION
fixes #157

the input event doesn't fire when the value is changed in code, so listen for the property change

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When the value is changed in react (or via the `.value` property in vanilla js) the track width is not updating.

Issue Number: #157

## What is the new behavior?

The component listens to the property change and updates the track width, since the `input` event doesn't fire in that case.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
