### PR TITLE
fix(range): update track width when value is changed programmatically (backport)

### DIFF
--- a/projects/core/custom-elements.json
+++ b/projects/core/custom-elements.json
@@ -45599,7 +45599,16 @@
             {
               "kind": "method",
               "name": "setTrackWidth",
-              "privacy": "private"
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "val",
+                  "optional": true,
+                  "type": {
+                    "text": "number"
+                  }
+                }
+              ]
             },
             {
               "kind": "field",

--- a/projects/core/src/range/range.element.spec.ts
+++ b/projects/core/src/range/range.element.spec.ts
@@ -47,4 +47,14 @@ describe('cds-range', () => {
     await componentIsStable(component);
     expect(getCssPropertyValue('--track-width', component)).toBe('77%');
   });
+
+  it('should update the track width style when the value is changed programmatically (no input event)', async () => {
+    await componentIsStable(component);
+    expect(getCssPropertyValue('--track-width', component)).toBe('50%');
+
+    component.inputControl.value = '75';
+
+    await componentIsStable(component);
+    expect(getCssPropertyValue('--track-width', component)).toBe('75%');
+  });
 });


### PR DESCRIPTION
fixes #157

the input event doesn't fire when the value is changed in code, so listen for the property change
