### PR TITLE
fix(react): update lit react version in package.lib.json

### DIFF
--- a/projects/react/package.lib.json
+++ b/projects/react/package.lib.json
@@ -17,7 +17,7 @@
   "typings": "./index.d.ts",
   "type": "module",
   "dependencies": {
-    "@lit-labs/react": "^1.0.1"
+    "@lit-labs/react": "^1.0.8"
   },
   "peerDependencies": {
     "react": ">= 16.13.1",


### PR DESCRIPTION
should have been done with #152

package/yarn locks aren't properly updating to the latest lit version without this

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

I updated lit-labs/react in #152, but forgot to update this file, so consumer's yarn locks and package lock files aren't updating the latest version

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
