### PR TITLE
fix(textarea): update disabled text color

### DIFF
--- a/projects/core/src/textarea/textarea.element.scss
+++ b/projects/core/src/textarea/textarea.element.scss
@@ -39,4 +39,5 @@
 
 :host([_disabled]) {
   --border: #{$cds-alias-object-border-width-100} solid #{$cds-alias-status-disabled};
+  --color: #{$cds-alias-status-disabled};
 }


### PR DESCRIPTION
fixes #165

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The text color in a disabled textarea didn't match the color of other disabled elements

Issue Number: #165 

## What is the new behavior?

The color now matches the color of other disabled inputs

<img width="979" alt="image" src="https://user-images.githubusercontent.com/9469374/189409625-5786a76c-a50f-4008-8e36-0c322251ccbe.png">


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
