### PR TITLE
fix(button): buttons starting with loading-state should be come enabled after

### DIFF
--- a/projects/core/src/button/button.element.spec.ts
+++ b/projects/core/src/button/button.element.spec.ts
@@ -279,6 +279,28 @@ describe('button element', () => {
       expect(component.disabled).not.toBeTruthy();
     });
 
+    it('should go back to enabled when loadingState changes back to default, starting non default', async () => {
+      console.log('my test');
+      const testElement2 = await createTestElement(html`
+        <cds-button loading-state="loading">
+          <span>${placeholderText}</span>
+        </cds-button>
+      `);
+
+      const component2 = testElement2.querySelector<CdsButton>('cds-button');
+
+      await componentIsStable(component2);
+      expect(component2.disabled).toBeTruthy();
+
+      component2.loadingState = ClrLoadingState.success;
+      await componentIsStable(component2);
+      expect(component2.disabled).toBeTruthy();
+
+      component2.loadingState = ClrLoadingState.default;
+      await componentIsStable(component2);
+      expect(component2.disabled).not.toBeTruthy();
+    });
+
     it('should stay disabled when loadingState changes back to default', async () => {
       await componentIsStable(component);
       component.disabled = true;

--- a/projects/core/src/button/button.element.ts
+++ b/projects/core/src/button/button.element.ts
@@ -97,7 +97,7 @@ export class CdsButton extends CdsBaseButton {
     super.firstUpdated(props);
 
     if (!this.isDefaultLoadingState(this.loadingState)) {
-      this.disabled = true;
+      super.disabled = true;
     }
   }
 
@@ -144,7 +144,8 @@ export class CdsButton extends CdsBaseButton {
     super.disabled = this._disabledExternally;
   }
 
-  // when the loading state changes, the disabled state should be set to what the consumer manually set, if set
+  // when the loading state changes,
+  //    the disabled state should be set back to what the consumer manually set (if they set it)
   // the setter here should never be called in the component, call super instead
   //  https://github.com/vmware-clarity/core/issues/129
   private _disabledExternally = false;


### PR DESCRIPTION

previous logic will restore a button to enabled when switching default -> loading/error -> default, but not if the button starts in a loadingState other than default

fixes #172

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When a button goes from default/undefined loading state -> loading or error -> default, the button will go from enabled -> disabled -> enabled. However, this logic didn't work if the button *starts* in a non-default loadingState

Issue Number: #172 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
