### PR TITLE
fix(modal): add bottom margin without cds-modal-actions

### DIFF
--- a/projects/core/src/modal/modal.element.ts
+++ b/projects/core/src/modal/modal.element.ts
@@ -94,7 +94,7 @@ export class CdsModal extends CdsInternalOverlay {
 
   private get modalFooterTemplate(): TemplateResult {
     if (this.modalFooter) {
-      return html`<div cds-layout="align-stretch p-x:lg p-b:lg">
+      return html`<div cds-layout="align-stretch p-x:lg">
         <slot name="modal-actions"></slot>
       </div>`;
     } else {
@@ -110,8 +110,8 @@ export class CdsModal extends CdsInternalOverlay {
       ${this.backdropTemplate}
       <div class="modal-dialog private-host" tabindex="-1" cds-layout="m:md m@md:xl">
         <div cds-layout="display:screen-reader-only">${this.i18n.contentStart}</div>
-        <div class="modal-content" cds-layout="vertical gap:sm gap@md:lg align:stretch">
-          <div cds-layout="horizontal gap:sm wrap:none align:vertical-center p-x:lg p-t:lg">
+        <div class="modal-content" cds-layout="vertical gap:sm gap@md:lg align:stretch p-y:lg">
+          <div cds-layout="horizontal gap:sm wrap:none align:vertical-center p-x:lg">
             <div>
               <slot name="modal-header"></slot>
             </div>

--- a/projects/core/src/modal/modal.stories.ts
+++ b/projects/core/src/modal/modal.stories.ts
@@ -180,7 +180,6 @@ export function headerActions() {
       <cds-modal-content>
         <p cds-text="body">Place holder text for the header actions modal example.</p>
       </cds-modal-content>
-      <cds-modal-actions></cds-modal-actions>
     </cds-modal>
   </cds-demo>`;
 }


### PR DESCRIPTION
fixes #174

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

If you don't have a cds-modal-actions element, there is no margin at the bottom of the modal. So you need the element even if you don't have any actions, which actually provides more margin than necessary due to the `gap` CSS between elements.

Issue Number: #174 

## What is the new behavior?

Padding is applied to the container, so will appear regardless of the elements rendered

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
