### PR TITLE
fix(list): use transparent marker for accessibility

### DIFF
--- a/projects/core/src/list/list.scss
+++ b/projects/core/src/list/list.scss
@@ -26,9 +26,11 @@ $list-default-unordered-type: disc;
 %kill-list-styles {
   padding-inline-start: 0 !important;
   margin: 0 !important;
-  // zero-width blank space added to help VoiceOver screen reader read a list-style-type none list
-  list-style: '\200B' !important;
-  list-style-position: inside !important;
+
+  // VoiceOver can't read a list-style-type none list, so use a transparent marker instead
+  li::marker {
+    color: transparent;
+  }
 }
 
 [cds-list] {


### PR DESCRIPTION
Fixes VPAT-612

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

VoiceOver can't properly read the unstyled list items as a list using the current approach.

Issue Number: VPAT-612

## What is the new behavior?

Use a transparent marker instead

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
