### PR TITLE
fix(dropdown): rename popup attribute to aria-controls

### DIFF
--- a/projects/core/src/button/button.element.spec.ts
+++ b/projects/core/src/button/button.element.spec.ts
@@ -280,7 +280,6 @@ describe('button element', () => {
     });
 
     it('should go back to enabled when loadingState changes back to default, starting non default', async () => {
-      console.log('my test');
       const testElement2 = await createTestElement(html`
         <cds-button loading-state="loading">
           <span>${placeholderText}</span>

--- a/projects/core/src/dropdown/dropdown.stories.mdx
+++ b/projects/core/src/dropdown/dropdown.stories.mdx
@@ -9,6 +9,14 @@ import { Meta, Props, Story, Preview } from '@web/storybook-prebuilt/addon-docs/
     This component or utility is offered as a preview. This means we are currently working on it and seeking feedback.
     Please be aware that this component or utility may have breaking changes before we finish working on it.
   </cds-alert>
+  <cds-alert>
+    <strong>Breaking:</strong> In 6.2.0, the `popup` attribute on the dropdown trigger was renamed to `aria-controls` to
+    avoid a console error in Chromium browsers. See{' '}
+    <a href="https://github.com/vmware-clarity/core/issues/140" target="_blank">
+      vmware-clarity/core#140 on GitHub
+    </a>{' '}
+    for details.
+  </cds-alert>
 </cds-alert-group>
 
 Dropdowns are a generic popup container that can be positioned on the screen. This means thay act as a container for
@@ -27,7 +35,7 @@ import '@cds/core/dropdown/register.js';
 ```
 
 ```html
-<cds-button popup="my-dropdown" id="my-button" onclick="document.getElementById('my-dropdown').hidden = false"
+<cds-button aria-controls="my-dropdown" id="my-button" onclick="document.getElementById('my-dropdown').hidden = false"
   >Open Dropdown</cds-button
 >
 <cds-dropdown anchor="my-button" id="my-dropdown" orientation="right not:top">
@@ -46,7 +54,7 @@ The dropdown consists of a number of components, some of which are optional.
 
 - **Trigger (optional)** The trigger is an element that shows the dropdown through user interaction, like a user clicking
   a button. There is no requirement that all dropdowns have a trigger. A trigger is associated with a dropdown by passing
-  the dropdown's id into the trigger's `popup` attribute. If a trigger is defined, the dropdown will manage its aria
+  the dropdown's id into the trigger's `aria-controls` attribute. If a trigger is defined, the dropdown will manage its aria
   attributes so that screen readers will associate the trigger with the dropdown. This will help screen readers identify
   the connection between the trigger and dropdown, as well as announce when the dropdown is open.
 

--- a/projects/core/src/dropdown/dropdown.stories.ts
+++ b/projects/core/src/dropdown/dropdown.stories.ts
@@ -59,7 +59,7 @@ class DemoDropdownBasic extends DemoDropdown {
         status="primary"
         type="button"
         @click=${() => (this.showOverlay = true)}
-        popup="demo-dropdown-basic-dd"
+        aria-controls="demo-dropdown-basic-dd"
         >Show Basic Dropdown</cds-button
       >
       <cds-dropdown
@@ -92,7 +92,7 @@ class DemoDropdownScrollable extends DemoDropdown {
         status="primary"
         type="button"
         @click=${() => (this.showOverlay = true)}
-        popup="demo-dropdown-scrollable-dd"
+        aria-controls="demo-dropdown-scrollable-dd"
         >Show Scrollable Dropdown</cds-button
       >
       <cds-dropdown
@@ -187,7 +187,7 @@ class DemoDropdownPointer extends DemoDropdown {
             status="primary"
             type="button"
             @click=${() => (this.showOverlay = true)}
-            popup="demo-pointer-dd"
+            aria-controls="demo-pointer-dd"
             id="demo-pointer-anchor"
             >Show Dropdown With Pointer</cds-button
           >
@@ -259,7 +259,7 @@ class DemoDropdownResponsive extends DemoDropdown {
         type="button"
         @click=${() => (this.showOverlay = true)}
         id="demo-responsive-anchor"
-        popup="demo-responsive-dd"
+        aria-controls="demo-responsive-dd"
         >Show Responsive Dropdown</cds-button
       >
       <cds-dropdown
@@ -303,7 +303,7 @@ class DemoDropdownClosable extends DemoDropdown {
         status="primary"
         type="button"
         @click=${() => (this.showOverlay = true)}
-        popup="demo-closable-dd"
+        aria-controls="demo-closable-dd"
         >Show Closable Dropdown</cds-button
       >
       <cds-dropdown
@@ -336,7 +336,11 @@ class DemoDropdownAltAnchored extends DemoDropdown {
   render() {
     return html` <div cds-layout="grid gap:md">
         <div cds-layout="col:4">
-          <cds-button status="primary" type="button" @click=${() => (this.showOverlay = true)} popup="demo-anchored-dd"
+          <cds-button
+            status="primary"
+            type="button"
+            @click=${() => (this.showOverlay = true)}
+            aria-controls="demo-anchored-dd"
             >Show Anchored Dropdown</cds-button
           >
         </div>
@@ -461,7 +465,7 @@ class DemoDropdownOrientation extends DemoDropdown {
             status="primary"
             type="button"
             @click=${() => (this.showOverlay = true)}
-            popup="demo-orientations-dd"
+            aria-controls="demo-orientations-dd"
             id="demo-orientations-anchor"
             >Show Dropdown</cds-button
           >
@@ -505,7 +509,7 @@ class DemoDropdownDarkTheme extends DemoDropdown {
         type="button"
         id="dark-theme-btn"
         @click=${() => (this.showOverlay = true)}
-        popup="demo-dark-dd"
+        aria-controls="demo-dark-dd"
         >Show Dark Theme Dropdown</cds-button
       >
       <cds-dropdown
@@ -549,7 +553,7 @@ class DemoDropdownInModal extends DemoDropdown {
           <p cds-text="body">
             This is an example of a modal with a dropdown inside of it. Click the button below to open the dropdown.
           </p>
-          <cds-button @click=${() => (this.showDropdown = true)} popup="demo-modal-dd" id="ddown-anchor"
+          <cds-button @click=${() => (this.showDropdown = true)} aria-controls="demo-modal-dd" id="ddown-anchor"
             >Open Dropdown</cds-button
           >
         </cds-modal-content>

--- a/projects/core/src/grid/detail/grid-detail.element.spec.ts
+++ b/projects/core/src/grid/detail/grid-detail.element.spec.ts
@@ -25,7 +25,7 @@ describe('cds-grid-detail', () => {
         <cds-grid-column>Column 3</cds-grid-column>
         <cds-grid-row>
           <cds-grid-cell>
-            <cds-button-action popup="detail" id="cell-1-action"></cds-button-action>
+            <cds-button-action aria-controls="detail" id="cell-1-action"></cds-button-action>
           </cds-grid-cell>
           <cds-grid-cell role="rowheader">Cell 1</cds-grid-cell>
           <cds-grid-cell>Cell 2</cds-grid-cell>
@@ -33,7 +33,7 @@ describe('cds-grid-detail', () => {
         </cds-grid-row>
         <cds-grid-row>
           <cds-grid-cell>
-            <cds-button-action popup="detail" id="cell-2-action"></cds-button-action>
+            <cds-button-action aria-controls="detail" id="cell-2-action"></cds-button-action>
           </cds-grid-cell>
           <cds-grid-cell role="rowheader">Cell 1</cds-grid-cell>
           <cds-grid-cell>Cell 2</cds-grid-cell>

--- a/projects/core/src/grid/docs/column-filter.story.ts
+++ b/projects/core/src/grid/docs/column-filter.story.ts
@@ -39,7 +39,7 @@ export function columnFilter() {
               ${column.label}
               ${i === 0
                 ? html`<cds-button-action
-                    popup="column-filter"
+                    aria-controls="column-filter"
                     @click=${(e: any) => (this.anchor = e.target)}
                     shape="filter"
                     .expanded=${!!this.search.length}

--- a/projects/core/src/grid/docs/column-visibility.story.ts
+++ b/projects/core/src/grid/docs/column-visibility.story.ts
@@ -44,7 +44,7 @@ export function columnVisibility() {
           )}
           <cds-grid-footer>
             <cds-button-action
-              popup="column-visbility"
+              aria-controls="column-visbility"
               @click=${(e: any) => (this.columnAnchor = e.target)}
               aria-label="filter column"
               shape="view-columns"

--- a/projects/core/src/grid/docs/footer.story.ts
+++ b/projects/core/src/grid/docs/footer.story.ts
@@ -44,7 +44,7 @@ export function footerActions() {
     @state() private showNotifications = false;
 
     get visibilityAnchor() {
-      return this.shadowRoot.querySelector('[popup="notifications"]');
+      return this.shadowRoot.querySelector('[aria-controls="notifications"]');
     }
 
     static styles = [
@@ -74,7 +74,7 @@ export function footerActions() {
           <cds-grid-footer>
             <div cds-layout="horizontal gap:lg">
               <cds-button-action
-                popup="notifications"
+                aria-controls="notifications"
                 @click=${() => (this.showNotifications = true)}
                 aria-label="notifications"
               >
@@ -82,7 +82,7 @@ export function footerActions() {
               </cds-button-action>
               <cds-button-inline
                 cds-layout="align:right"
-                popup="column-visbility"
+                aria-controls="column-visbility"
                 @click=${(e: any) => (this.columnAnchor = e.target)}
                 aria-label="filter column"
                 .expanded=${!this.checked(this.all)}

--- a/projects/core/src/grid/docs/kitchen-sink.story.ts
+++ b/projects/core/src/grid/docs/kitchen-sink.story.ts
@@ -75,7 +75,7 @@ export function kitchenSink() {
           <cds-grid-column resizable width="180">
             Host
             <cds-button-action
-              popup="id-filter"
+              aria-controls="id-filter"
               @click=${(e: any) => (this.state = { ...this.state, idFilterAnchor: e.target })}
               aria-label="column filter options"
               shape="filter"
@@ -109,7 +109,7 @@ export function kitchenSink() {
               </cds-grid-cell>
               <cds-grid-cell>
                 <cds-button-expand
-                  popup="row-detail"
+                  aria-controls="row-detail"
                   action="detail"
                   aria-label="${entry.id} details"
                   .expanded=${this.currentDetail?.id === entry.id}
@@ -134,7 +134,7 @@ export function kitchenSink() {
           )}
           <cds-grid-footer>
             <cds-button-action
-              popup="column-visibility"
+              aria-controls="column-visibility"
               @click=${(e: any) => (this.state = { ...this.state, columnsDropdownAnchor: e.target })}
               aria-label="filter columns"
               shape="view-columns"

--- a/projects/core/src/grid/docs/row-action.story.ts
+++ b/projects/core/src/grid/docs/row-action.story.ts
@@ -33,7 +33,7 @@ export function rowAction() {
             row => html` <cds-grid-row>
               <cds-grid-cell>
                 <cds-button-action
-                  popup="row-actions"
+                  aria-controls="row-actions"
                   aria-label="${row.id} actions"
                   @click=${(e: any) => this.select(e.target, row)}
                 ></cds-button-action>

--- a/projects/core/src/grid/docs/row-detail.story.ts
+++ b/projects/core/src/grid/docs/row-detail.story.ts
@@ -24,7 +24,7 @@ export function rowDetail() {
           row => html` <cds-grid-row>
             <cds-grid-cell>
               <cds-button-expand
-                popup="row-detail"
+                aria-controls="row-detail"
                 action="detail"
                 aria-label="${row.id} details"
                 .expanded=${this.selectedRow?.id === row.id}
@@ -89,7 +89,7 @@ export function rowDetailExpand() {
           row => html` <cds-grid-row .position=${this.selectedRow?.id === row.id ? 'fixed' : ''}>
             <cds-grid-cell>
               <cds-button-expand
-                popup="row-expand"
+                aria-controls="row-expand"
                 aria-label="${row.id} details"
                 .expanded=${this.selectedRow?.id === row.id}
                 @click=${(e: any) => this.showDetail(e.target, row)}

--- a/projects/core/src/grid/docs/row-swappable.story.ts
+++ b/projects/core/src/grid/docs/row-swappable.story.ts
@@ -43,7 +43,7 @@ export function rowSwappable() {
                 </cds-grid-cell>
                 <cds-grid-cell>
                   <cds-button-action
-                    popup="migrate-dropdown"
+                    aria-controls="migrate-dropdown"
                     aria-label="${row.id} actions"
                     @click=${(e: any) => this.selectEntry(row, e.target)}
                   ></cds-button-action>
@@ -70,7 +70,7 @@ export function rowSwappable() {
                 </cds-grid-cell>
                 <cds-grid-cell>
                   <cds-button-action
-                    popup="migrate-dropdown"
+                    aria-controls="migrate-dropdown"
                     aria-label="${row.id} actions"
                     @click=${(e: any) => this.selectEntry(row, e.target)}
                   ></cds-button-action>

--- a/projects/core/src/grid/docs/rtl.story.ts
+++ b/projects/core/src/grid/docs/rtl.story.ts
@@ -25,7 +25,7 @@ export function rtl() {
           row => html` <cds-grid-row>
             <cds-grid-cell>
               <cds-button-expand
-                popup="row-detail"
+                aria-controls="row-detail"
                 action="detail"
                 aria-label="${row.id} details"
                 .expanded=${this.selectedRow?.id === row.id}

--- a/projects/core/src/grid/grid.a11y.ts
+++ b/projects/core/src/grid/grid.a11y.ts
@@ -319,7 +319,7 @@ describe('cds-grid row action', () => {
           <cds-grid-row>
             <cds-grid-cell>
               <cds-button-action
-                popup="row-actions"
+                aria-controls="row-actions"
                 aria-label="vm-host-001 actions"
                 @click=${(e: any) => (this.anchor = e.target)}
               ></cds-button-action>
@@ -467,7 +467,7 @@ describe('cds-grid row detail', () => {
         <cds-grid-row>
           <cds-grid-cell>
             <cds-button-expand
-              popup="row-detail"
+              aria-controls="row-detail"
               action="detail"
               aria-label="view details"
               .expanded=${this.open}
@@ -539,7 +539,7 @@ describe('cds-grid column filter', () => {
           <cds-grid-column
             >Host
             <cds-button-action
-              popup="column-filter"
+              aria-controls="column-filter"
               @click=${(e: any) => (this.anchor = e.target)}
               shape="filter"
               aria-label="search hosts"

--- a/projects/core/src/internal-components/popup/popup.stories.ts
+++ b/projects/core/src/internal-components/popup/popup.stories.ts
@@ -37,7 +37,12 @@ export const test = () => {
     }
   }
 
-  return html` <cds-button id="${anchorId}" status="primary" type="button" @click=${showOverlay} popup="${popupId2}"
+  return html` <cds-button
+      id="${anchorId}"
+      status="primary"
+      type="button"
+      @click=${showOverlay}
+      aria-controls="${popupId2}"
       >Show</cds-button
     >
     <cds-internal-popup hidden id="${popupId2}" aria-labelledby="${popupId2}-title" anchor="${anchorId}">
@@ -74,7 +79,7 @@ export const scrollTest = () => {
       status="primary"
       type="button"
       @click=${showScrollingPopup}
-      popup="${popupId2}"
+      aria-controls="${popupId2}"
       >Show Scrolling Popup</cds-button
     >
     <cds-internal-popup hidden id="${popupId2}" aria-labelledby="${popupId2}-title">
@@ -131,7 +136,7 @@ export const responsiveTest = () => {
       status="primary"
       type="button"
       @click=${showScrollingPopup}
-      popup="${popupId2}"
+      aria-controls="${popupId2}"
       >Show Responsive Popup</cds-button
     >
     <cds-internal-popup hidden id="${popupId2}" aria-labelledby="${popupId2}-title" orientation="none">

--- a/projects/core/src/internal/controllers/aria-popup-trigger.controller.spec.ts
+++ b/projects/core/src/internal/controllers/aria-popup-trigger.controller.spec.ts
@@ -6,14 +6,12 @@
 
 import { html, LitElement } from 'lit';
 import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
-import { customElement, property } from '@cds/core/internal';
+import { customElement } from '@cds/core/internal';
 import { ariaPopupTrigger } from './aria-popup-trigger.controller.js';
 
 @ariaPopupTrigger<AriaPopupTriggerControllerTestElement>()
 @customElement('aria-popup-controller-test-element')
-class AriaPopupTriggerControllerTestElement extends LitElement {
-  @property({ type: String }) popup: string;
-}
+class AriaPopupTriggerControllerTestElement extends LitElement {}
 
 describe('aria-popup-trigger.controller', () => {
   let component: AriaPopupTriggerControllerTestElement;
@@ -23,7 +21,7 @@ describe('aria-popup-trigger.controller', () => {
   beforeEach(async () => {
     element = await createTestElement(
       html`
-        <aria-popup-controller-test-element id="initme" popup="popup-el"></aria-popup-controller-test-element>
+        <aria-popup-controller-test-element id="initme" aria-controls="popup-el"></aria-popup-controller-test-element>
         <aria-popup-controller-test-element id="dontinitme"></aria-popup-controller-test-element>
       `
     );
@@ -37,15 +35,13 @@ describe('aria-popup-trigger.controller', () => {
 
   it('should initialize aria attributes for popup type triggers', async () => {
     await componentIsStable(component);
-    expect(component.ariaControls).toBe('popup-el');
     expect(component.ariaHasPopup).toBe('true');
     expect(component.ariaExpanded).toBe('false');
   });
 
   it('should NOT initialize aria attributes for triggers without a popup id', async () => {
     await componentIsStable(noponent);
-    expect(noponent.hasAttribute('popup')).toBe(false);
-    expect(noponent.ariaControls).toBe(undefined);
+    expect(noponent.hasAttribute('aria-controls')).toBe(false);
     expect(noponent.ariaHasPopup).toBe(null);
     expect(noponent.ariaExpanded).toBe(null);
   });

--- a/projects/core/src/internal/controllers/aria-popup-trigger.controller.ts
+++ b/projects/core/src/internal/controllers/aria-popup-trigger.controller.ts
@@ -6,24 +6,21 @@
 
 import { ReactiveController, ReactiveElement } from 'lit';
 
-export type AriaPopupTrigger = { popup: string };
-
 /**
  * Provides all nessesary aria-* attributes to create a vaild aria popup trigger.
  * Used in combination of the `@ariaPopup` controller.
  */
-export function ariaPopupTrigger<T extends ReactiveElement & AriaPopupTrigger>(): ClassDecorator {
+export function ariaPopupTrigger<T extends ReactiveElement>(): ClassDecorator {
   return (target: any) => target.addInitializer((instance: T) => new AriaPopupTriggerController(instance));
 }
 
-export class AriaPopupTriggerController<T extends ReactiveElement & AriaPopupTrigger> implements ReactiveController {
+export class AriaPopupTriggerController<T extends ReactiveElement> implements ReactiveController {
   constructor(private host: T) {
     this.host.addController(this);
   }
 
   hostConnected() {
-    if (this.host.popup) {
-      this.host.ariaControls = this.host.popup;
+    if (this.host.hasAttribute('aria-controls') || this.host.ariaControls) {
       this.host.ariaHasPopup = 'true';
       this.host.ariaExpanded = 'false';
     }

--- a/projects/core/src/internal/controllers/aria-popup.controller.spec.ts
+++ b/projects/core/src/internal/controllers/aria-popup.controller.spec.ts
@@ -22,8 +22,8 @@ describe('aria-popup.controller', () => {
 
   beforeEach(async () => {
     element = await createTestElement(
-      html` <div id="trigger-1" popup="popup-el"></div>
-        <div id="trigger-2" popup="popup-el"></div>
+      html` <div id="trigger-1" aria-controls="popup-el"></div>
+        <div id="trigger-2" aria-controls="popup-el"></div>
         <aria-popup-controller-test-element id="popup-el" hidden></aria-popup-controller-test-element>`
     );
     component = element.querySelector<AriaPopupControllerTestElement>('aria-popup-controller-test-element');

--- a/projects/core/src/internal/controllers/aria-popup.controller.stories.mdx
+++ b/projects/core/src/internal/controllers/aria-popup.controller.stories.mdx
@@ -13,19 +13,24 @@ a popup type component with an trigger/trigger.
 
 ## Consumer Usage
 
-Emulating the [popup API proposal](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/Popup/explainer.md) the
-controllers will associate the two components via the `trigger` and `popup` attr/properties.
-This will add the appropriate aria attributes including, `aria-controls`, `aria-haspopup` and `aria-expanded`.
+Originally, the controller was intended to emulate the
+[popup API proposal](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/Popup/explainer.md).
+The controllers associated the two components via the `trigger` and `popup` attr/properties,
+and added the appropriate aria attributes including, `aria-controls`, `aria-haspopup` and `aria-expanded`.
 Then the popup component is removed from the DOM or has a `hidden` attr applied it will updated the `aria-expanded`
 attribute on its associated trigger.
 
+Chrome [implemented the attribute](https://bugs.chromium.org/p/chromium/issues/detail?id=1307772)
+with different behavior matching the [Open UI API spec](https://open-ui.org/components/popup.research.explainer) and now logs errors in the console about using the prop,
+so the attribute was renamed from `popup` to `aria-controls` in 6.
+
 ```html
 <!-- user template -->
-<demo-trigger popup="my-popup" id="my-trigger">trigger</demo-trigger>
+<demo-trigger aria-controls="my-popup" id="my-trigger">trigger</demo-trigger>
 <demo-popup hidden anchor="my-trigger" id="my-popup">popup</demo-popup>
 
 <!-- rendered output -->
-<demo-trigger popup="my-popup" id="my-trigger" aria-controls="my-popup" aria-haspopup="true" aria-expanded="false">trigger</demo-anchor>
+<demo-trigger aria-controls="my-popup" id="my-trigger" aria-controls="my-popup" aria-hasaria-controls="true" aria-expanded="false">trigger</demo-anchor>
 <demo-popup hidden anchor="my-trigger" id="my-popup">popup</demo-popup>
 ```
 
@@ -55,7 +60,12 @@ class DemoPopupController extends LitElement {
 
   render() {
     return html`
-      <aria-trigger popup="my-popup" id="my-trigger" role="button" tabindex="0" @click=${() => (this.show = true)}
+      <aria-trigger
+        aria-controls="my-popup"
+        id="my-trigger"
+        role="button"
+        tabindex="0"
+        @click=${() => (this.show = true)}
         >trigger</aria-trigger
       >
       <aria-popup ?hidden=${!this.show} anchor="my-trigger" id="my-popup" @click=${() => (this.show = false)}

--- a/projects/core/src/internal/controllers/aria-popup.controller.ts
+++ b/projects/core/src/internal/controllers/aria-popup.controller.ts
@@ -44,11 +44,11 @@ export class AriaPopupController<T extends AriaPopup> implements ReactiveControl
   }
 
   private updateTrigger(expanded: boolean) {
-    if (this.trigger.current?.hasAttribute('popup')) {
+    if (this.trigger.current?.hasAttribute('aria-controls')) {
       this.trigger.current.ariaExpanded = `${expanded}`;
     }
 
-    if (this.trigger.prev?.hasAttribute('popup') && this.trigger.prev !== this.trigger.current) {
+    if (this.trigger.prev?.hasAttribute('aria-controls') && this.trigger.prev !== this.trigger.current) {
       this.trigger.prev.ariaExpanded = 'false';
     }
   }

--- a/projects/core/src/internal/controllers/controller.stories.ts
+++ b/projects/core/src/internal/controllers/controller.stories.ts
@@ -355,7 +355,12 @@ export function ariaPopupController() {
 
     render() {
       return html`
-        <demo-trigger popup="my-popup" id="my-trigger" role="button" tabindex="0" @click=${() => (this.show = true)}
+        <demo-trigger
+          aria-controls="my-popup"
+          id="my-trigger"
+          role="button"
+          tabindex="0"
+          @click=${() => (this.show = true)}
           >trigger</demo-trigger
         ><br />
         <demo-popup ?hidden=${!this.show} anchor="my-trigger" id="my-popup" @click=${() => (this.show = false)}

--- a/projects/core/src/signpost/signpost.stories.mdx
+++ b/projects/core/src/signpost/signpost.stories.mdx
@@ -28,7 +28,7 @@ import '@cds/core/signpost/register.js';
 ```
 
 ```html
-<cds-button popup="my-signpost" id="my-button" onclick="document.getElementById('my-signpost').hidden = false"
+<cds-button aria-controls="my-signpost" id="my-button" onclick="document.getElementById('my-signpost').hidden = false"
   >Open Signpost</cds-button
 >
 <cds-signpost anchor="my-button" id="my-signpost" orientation="right bottom">

--- a/projects/core/src/signpost/signpost.stories.ts
+++ b/projects/core/src/signpost/signpost.stories.ts
@@ -64,7 +64,7 @@ class DemoSignpostBasic extends DemoSignpost {
         status="primary"
         type="button"
         @click=${() => (this.showOverlay = true)}
-        popup="demo-signpost-basic"
+        aria-controls="demo-signpost-basic"
         >Show Basic Signpost</cds-button
       >
       <cds-signpost
@@ -112,7 +112,7 @@ class DemoSignpostTrigger extends LitElement {
   render() {
     return html`
       <div cds-layout="horizontal gap:sm">
-        <cds-button id="demo-anchor" @click=${() => (this.showOverlay = true)} popup="demo-signpost">
+        <cds-button id="demo-anchor" @click=${() => (this.showOverlay = true)} aria-controls="demo-signpost">
           Show Trigger Signpost
         </cds-button>
         <cds-button id="demo-trigger" status="danger" action="outline"> Trigger Receives Focus On Close </cds-button>
@@ -251,7 +251,7 @@ class DemoSignpostTour extends DemoSignpost {
               }}
               status="primary"
               id="${this.signpostButtonIdPrefix}-0"
-              popup="${this.signpostId}"
+              aria-controls="${this.signpostId}"
               >Click to Start Tour</cds-button
             >
           </cds-placeholder>
@@ -357,7 +357,7 @@ class DemoSignpostStacked extends DemoSignpost {
           status="primary"
           type="button"
           @click=${() => (this.showOverlay = true)}
-          popup="demo-signpost-stacked"
+          aria-controls="demo-signpost-stacked"
           >Show Modal With Signpost</cds-button
         >
       </div>
@@ -456,7 +456,7 @@ export function custompointer() {
       @click=${() => {
         toggleCustomPointerSignpost(true);
       }}
-      popup="${customPointerSignpostDemoId}"
+      aria-controls="${customPointerSignpostDemoId}"
       >Show Signpost With Custom Pointer</cds-button
     >
     <cds-signpost
@@ -522,7 +522,7 @@ class DemoSignpostDarkTheme extends DemoSignpost {
         status="primary"
         type="button"
         @click=${() => (this.showOverlay = true)}
-        popup="demo-signpost-dark-theme"
+        aria-controls="demo-signpost-dark-theme"
         >Show Dark Theme Signpost</cds-button
       >
       <cds-signpost
@@ -588,7 +588,7 @@ class DemoSignpostCustom extends DemoSignpost {
           status="primary"
           type="button"
           @click=${() => (this.showOverlay = true)}
-          popup="demo-signpost-custom"
+          aria-controls="demo-signpost-custom"
           >Show Custom Signpost</cds-button
         >
         <cds-signpost

--- a/projects/react/App.tsx
+++ b/projects/react/App.tsx
@@ -303,7 +303,7 @@ function DropdownDemo() {
       <div cds-layout="horizontal gap:lg p-y:md">
         <CdsButton
           id="dropdown-btn"
-          popup="my-dropdown"
+          aria-controls="my-dropdown"
           onClick={() => {
             const timer = setTimeout(() => {
               setDropdownOpen(true);
@@ -315,7 +315,7 @@ function DropdownDemo() {
         </CdsButton>
         <CdsButton
           id="resp-dropdown-btn"
-          popup="my-resp-dropdown"
+          aria-controls="my-resp-dropdown"
           onClick={() => {
             const timer = setTimeout(() => {
               setResponsiveDropdownOpen(true);
@@ -327,7 +327,7 @@ function DropdownDemo() {
         </CdsButton>
         <CdsButton
           id="signpost-btn"
-          popup="my-signpost"
+          aria-controls="my-signpost"
           onClick={() => {
             const timer = setTimeout(() => {
               setSignpostOpen(true);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The popup attribute conflicts with the Popup API that chromium has started implementing and results in errors logged in the console. See development status: https://chromestatus.com/feature/5463833265045504

Issue Number: #140

## What is the new behavior?

This renames the attribute to aria-controls, which is semantically correct. This is a breaking change

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

Applications will lose aria attribute setting if they don't rename the attribute in their code. The component is a beta components so this change should be acceptable.

## Other information
