### PR TITLE
fix(control): apply control action padding when visibility changes

### DIFF
--- a/projects/core/custom-elements.json
+++ b/projects/core/custom-elements.json
@@ -5090,6 +5090,15 @@
             },
             {
               "kind": "method",
+              "name": "setupPositioningListeners",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "CdsControl",
+                "module": "forms/control/control.element.js"
+              }
+            },
+            {
+              "kind": "method",
               "name": "setActionOffsetPadding",
               "privacy": "private",
               "inheritedFrom": {
@@ -5782,6 +5791,15 @@
             },
             {
               "kind": "method",
+              "name": "setupPositioningListeners",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "CdsControl",
+                "module": "forms/control/control.element.js"
+              }
+            },
+            {
+              "kind": "method",
               "name": "setActionOffsetPadding",
               "privacy": "private",
               "inheritedFrom": {
@@ -6413,6 +6431,15 @@
             {
               "kind": "method",
               "name": "setupHTML5Validation",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "CdsControl",
+                "module": "forms/control/control.element.js"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "setupPositioningListeners",
               "privacy": "private",
               "inheritedFrom": {
                 "name": "CdsControl",
@@ -7814,6 +7841,15 @@
             },
             {
               "kind": "method",
+              "name": "setupPositioningListeners",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "CdsControl",
+                "module": "forms/control/control.element.js"
+              }
+            },
+            {
+              "kind": "method",
               "name": "setActionOffsetPadding",
               "privacy": "private",
               "inheritedFrom": {
@@ -9121,6 +9157,15 @@
             },
             {
               "kind": "method",
+              "name": "setupPositioningListeners",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "CdsControl",
+                "module": "forms/control/control.element.js"
+              }
+            },
+            {
+              "kind": "method",
               "name": "setActionOffsetPadding",
               "privacy": "private",
               "inheritedFrom": {
@@ -9758,6 +9803,11 @@
             {
               "kind": "method",
               "name": "setupHTML5Validation",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "setupPositioningListeners",
               "privacy": "private"
             },
             {
@@ -36102,6 +36152,15 @@
             },
             {
               "kind": "method",
+              "name": "setupPositioningListeners",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "CdsControl",
+                "module": "forms/control/control.element.js"
+              }
+            },
+            {
+              "kind": "method",
               "name": "setActionOffsetPadding",
               "privacy": "private",
               "inheritedFrom": {
@@ -51419,6 +51478,15 @@
             },
             {
               "kind": "method",
+              "name": "setupPositioningListeners",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "CdsControl",
+                "module": "forms/control/control.element.js"
+              }
+            },
+            {
+              "kind": "method",
               "name": "setActionOffsetPadding",
               "privacy": "private",
               "inheritedFrom": {
@@ -52912,6 +52980,15 @@
             },
             {
               "kind": "method",
+              "name": "setupPositioningListeners",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "CdsControl",
+                "module": "forms/control/control.element.js"
+              }
+            },
+            {
+              "kind": "method",
               "name": "setActionOffsetPadding",
               "privacy": "private",
               "inheritedFrom": {
@@ -53604,6 +53681,15 @@
             },
             {
               "kind": "method",
+              "name": "setupPositioningListeners",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "CdsControl",
+                "module": "forms/control/control.element.js"
+              }
+            },
+            {
+              "kind": "method",
               "name": "setActionOffsetPadding",
               "privacy": "private",
               "inheritedFrom": {
@@ -54273,6 +54359,15 @@
             {
               "kind": "method",
               "name": "setupHTML5Validation",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "CdsControl",
+                "module": "forms/control/control.element.js"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "setupPositioningListeners",
               "privacy": "private",
               "inheritedFrom": {
                 "name": "CdsControl",
@@ -54962,6 +55057,15 @@
             {
               "kind": "method",
               "name": "setupHTML5Validation",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "CdsControl",
+                "module": "forms/control/control.element.js"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "setupPositioningListeners",
               "privacy": "private",
               "inheritedFrom": {
                 "name": "CdsControl",
@@ -55688,6 +55792,15 @@
             {
               "kind": "method",
               "name": "setupHTML5Validation",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "CdsControl",
+                "module": "forms/control/control.element.js"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "setupPositioningListeners",
               "privacy": "private",
               "inheritedFrom": {
                 "name": "CdsControl",
@@ -56481,6 +56594,15 @@
             {
               "kind": "method",
               "name": "setupHTML5Validation",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "CdsControl",
+                "module": "forms/control/control.element.js"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "setupPositioningListeners",
               "privacy": "private",
               "inheritedFrom": {
                 "name": "CdsControl",
@@ -58304,6 +58426,15 @@
             },
             {
               "kind": "method",
+              "name": "setupPositioningListeners",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "CdsControl",
+                "module": "forms/control/control.element.js"
+              }
+            },
+            {
+              "kind": "method",
               "name": "setActionOffsetPadding",
               "privacy": "private",
               "inheritedFrom": {
@@ -58967,6 +59098,15 @@
             {
               "kind": "method",
               "name": "setupHTML5Validation",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "CdsControl",
+                "module": "forms/control/control.element.js"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "setupPositioningListeners",
               "privacy": "private",
               "inheritedFrom": {
                 "name": "CdsControl",
@@ -60144,6 +60284,15 @@
             {
               "kind": "method",
               "name": "setupHTML5Validation",
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "CdsControl",
+                "module": "forms/control/control.element.js"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "setupPositioningListeners",
               "privacy": "private",
               "inheritedFrom": {
                 "name": "CdsControl",

--- a/projects/core/src/forms/control/control.element.ts
+++ b/projects/core/src/forms/control/control.element.ts
@@ -23,6 +23,7 @@ import {
   hasAriaLabelTypeAttr,
   calculateOptimalLayout,
   responsive,
+  elementVisible,
 } from '@cds/core/internal';
 import { CdsControlAction } from '../control-action/control-action.element.js';
 import { CdsControlMessage } from './../control-message/control-message.element.js';
@@ -288,7 +289,7 @@ export class CdsControl extends LitElement {
     super.firstUpdated(props);
     this.setupHostAttributes();
     this.setupHTML5Validation();
-    this.setActionOffsetPadding();
+    this.setupPositioningListeners();
     this.setupResponsive();
     this.setupDescribedByUpdates();
     this.setupLabelLayout();
@@ -340,6 +341,12 @@ export class CdsControl extends LitElement {
     if (!this.inputControl?.form?.noValidate && this.validate) {
       syncHTML5Validation(this, Array.from(this.messages));
     }
+  }
+
+  private setupPositioningListeners() {
+    this.setActionOffsetPadding();
+    // https://github.com/vmware-clarity/core/issues/182
+    this.observers.push(elementVisible(this.inputControl, () => this.setActionOffsetPadding()));
   }
 
   private async setActionOffsetPadding() {


### PR DESCRIPTION
fixes #182

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The padding is set for the control action only on the initial render, in `firstUpdated`. If the element is hidden at the time, the padding will be incorrect when the element becomes visible.  

Issue Number: #182 

## What is the new behavior?

There's now an intersection observer listening for visibility changes that will set the padding correctly

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
