### PR TITLE
fix(shim): match light ng-clarity vertical nav background colors

### DIFF
--- a/projects/core/src/styles/shim.clr-ui.scss
+++ b/projects/core/src/styles/shim.clr-ui.scss
@@ -908,3 +908,9 @@
     --clr-btn-icon-disabled-color: var(--cds-global-typography-color-100);
   }
 }
+
+[cds-theme~='light'] {
+  --clr-vertical-nav-bg-color: var(--cds-global-color-gray-200);
+  --clr-vertical-nav-active-bg-color: var(--cds-global-color-gray-0);
+  --clr-vertical-nav-hover-bg-color: var(--cds-global-color-gray-400);
+}


### PR DESCRIPTION
closes #195

## PR Checklist

Please check if your PR fulfills the following requirements:

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [x] If applicable, have a visual design approval

## PR Type

Fix (sort of)

## What is the current behavior?

The light theme shim uses a lighter background color than ng-clarity for the vertical nav.

Issue Number: #195

## What is the new behavior?

The light theme shim uses exactly the same background colors as ng-clarity for the vertical nav. Other themes are unaffected.

## Does this PR introduce a breaking change?

No