### PR TITLE
fix(shim): add mappings for datagrid loading background color

### DIFF
--- a/projects/core/src/styles/shim.clr-ui.scss
+++ b/projects/core/src/styles/shim.clr-ui.scss
@@ -877,6 +877,10 @@
 
   --clr-datagrid-placeholder-color: var(--cds-global-color-gray-700); // var(--clr-color-neutral-700);
 
+  --clr-datagrid-loading-background: var(
+    --cds-alias-object-opacity-100
+  ); // #{$clr-datagrid-loading-background}; // hsla(0, 0%, 100%, 0.6);
+
   .login-wrapper {
     // these are set in the ng css, but seem to be getting overridden somewhere
     --clr-login-background-color: var(--clr-global-app-background);
@@ -913,4 +917,10 @@
   --clr-vertical-nav-bg-color: var(--cds-global-color-gray-200);
   --clr-vertical-nav-active-bg-color: var(--cds-global-color-gray-0);
   --clr-vertical-nav-hover-bg-color: var(--cds-global-color-gray-400);
+}
+
+[cds-theme~='dark'] {
+  --clr-datagrid-loading-background: var(
+    --cds-alias-object-opacity-300
+  ); // #{$clr-datagrid-loading-background}; // rgba(0, 0, 0, 0.5);
 }


### PR DESCRIPTION
## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [x] If applicable, have a visual design approval
  - I worked with Colin on this.

## PR Type

Bugfix

## What is the current behavior?

The shim doesn't map the `--clr-datagrid-loading-background` color. This causes the ng-clarity light color to "leak" when using the cds dark theme.

![image](https://user-images.githubusercontent.com/7399499/211919507-5e14f8ac-c50e-4778-8bcd-fcb977a011ef.png)

## What is the new behavior?

This shim maps the `--clr-datagrid-loading-background` to `--cds-alias-object-opacity-100` and `--cds-alias-object-opacity-300` for the light and dark theme, respectively.

## Does this PR introduce a breaking change?

No.