### PR TITLE
fix(shim): map info alert close icon color correctly

### DIFF
--- a/projects/core/src/styles/shim.clr-ui.scss
+++ b/projects/core/src/styles/shim.clr-ui.scss
@@ -288,7 +288,7 @@
   --clr-alert-info-icon-color: var(
     --clr-alert-info-font-color
   ); // var(--cds-global-color-blue-800); // var(--clr-color-action-800);
-  --clr-alert-info-close-icon-color: var(---clr-alert-info-font-color);
+  --clr-alert-info-close-icon-color: var(--clr-alert-info-font-color);
   --clr-alert-info-action-color: var(--clr-alert-info-font-color);
 
   // Success type


### PR DESCRIPTION
## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

There was an extra dash in the `--clr-alert-info-close-icon-color` color variable mapping.

## What is the new behavior?

There is not an extra dash in the `--clr-alert-info-close-icon-color` color variable mapping.

## Does this PR introduce a breaking change?

No.