### PR TITLE
fix(datagrid): prevent error when resizing columns

### DIFF
--- a/projects/core/src/internal/controllers/touch.controller.ts
+++ b/projects/core/src/internal/controllers/touch.controller.ts
@@ -35,7 +35,7 @@ export class TouchController<T extends Touch> implements ReactiveController {
   }
 
   private start(e: PointerEvent) {
-    if ((e as any).path.find((el: any) => el === this.host)) {
+    if (e.composedPath().find((el: any) => el === this.host)) {
       this.startPosition = { x: e.clientX, y: e.clientY };
       document.addEventListener('pointerup', this.endHandler, { passive: true });
       document.addEventListener('pointermove', this.moveHandler, { passive: true });


### PR DESCRIPTION
The `Event.path` property is nonstandard.

closes #216

## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

Error when resizing datagrid columns.

Issue Number: #216

## What is the new behavior?

No error when resizing datagrid columns.

## Does this PR introduce a breaking change?

No.