### PR TITLE
fix(icons): use the non-shade alias color for info status icons

### DIFF
--- a/projects/core/src/icon/icon.element.scss
+++ b/projects/core/src/icon/icon.element.scss
@@ -88,7 +88,7 @@ svg {
 }
 
 :host([status='info']) {
-  --color: #{$cds-alias-status-info-shade};
+  --color: #{$cds-alias-status-info};
 }
 
 :host([inverse]) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The current `info` status icons are colored with the `shade` variant, which gives the icon a very low contrast in dark theme.

<img width="412" alt="Screen Shot 2023-04-11 at 11 36 50 AM" src="https://user-images.githubusercontent.com/90871916/231214936-da972b21-731a-403b-8556-a576e8a0d845.png">
<img width="415" alt="Screen Shot 2023-04-11 at 11 37 09 AM" src="https://user-images.githubusercontent.com/90871916/231215003-90d822e7-674c-4193-a0af-d70d120b387a.png">

This is particularly true for regular-sized icons (i.e. smaller than `lg`):

<img width="204" alt="Screen Shot 2023-04-11 at 11 40 29 AM" src="https://user-images.githubusercontent.com/90871916/231215881-5ebed7cf-e1f6-46b9-9983-54790f86d6ba.png">

Issue Number: N/A

## What is the new behavior?

This change aligns the info icons more closely with, well, most everything else such as `cds-button`s which are displayed using the non-shade version, as well as non-info icons. As you can tell below, the impact on light theme is negligible, but in dark theme the contrast seems much better:

<img width="422" alt="Screen Shot 2023-04-11 at 11 37 59 AM" src="https://user-images.githubusercontent.com/90871916/231215200-1405a69e-1638-41af-83e1-0ca03d41b8b0.png">
<img width="412" alt="Screen Shot 2023-04-11 at 11 38 11 AM" src="https://user-images.githubusercontent.com/90871916/231215262-4b016a8a-b1d5-4e02-8af8-8097a4867990.png">

And on smaller icons:

<img width="197" alt="Screen Shot 2023-04-11 at 11 42 30 AM" src="https://user-images.githubusercontent.com/90871916/231216476-56a1b795-9c6f-4cd6-8e7b-be60052a29a2.png">

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
