### PR TITLE
fix(icon): add missing `neutral` badge and status

### DIFF
--- a/projects/core/custom-elements.json
+++ b/projects/core/custom-elements.json
@@ -11557,7 +11557,7 @@
               "kind": "field",
               "name": "status",
               "type": {
-                "text": "info | success | warning | danger"
+                "text": "neutral | info | success | warning | danger"
               },
               "description": "Changes color of icon fills and outlines",
               "attribute": "status"
@@ -11648,7 +11648,7 @@
             {
               "name": "status",
               "type": {
-                "text": "info | success | warning | danger"
+                "text": "neutral | info | success | warning | danger"
               },
               "description": "Changes color of icon fills and outlines",
               "fieldName": "status"

--- a/projects/core/custom-elements.json
+++ b/projects/core/custom-elements.json
@@ -11576,7 +11576,7 @@
               "kind": "field",
               "name": "badge",
               "type": {
-                "text": "info | success | warning | danger | inherit | warning"
+                "text": "neutral | info | success | warning | danger | inherit | warning"
               },
               "description": "-triangle | inherit-triangle}",
               "attribute": "badge"
@@ -11665,7 +11665,7 @@
             {
               "name": "badge",
               "type": {
-                "text": "info | success | warning | danger | inherit | warning"
+                "text": "neutral | info | success | warning | danger | inherit | warning"
               },
               "description": "-triangle | inherit-triangle}",
               "fieldName": "badge"

--- a/projects/core/src/icon/icon.element.scss
+++ b/projects/core/src/icon/icon.element.scss
@@ -91,6 +91,10 @@ svg {
   --color: #{$cds-alias-status-info};
 }
 
+:host([status='neutral']) {
+  --color: #{$cds-alias-status-neutral};
+}
+
 :host([inverse]) {
   --color: #{$cds-global-color-construction-200};
 }

--- a/projects/core/src/icon/icon.element.scss
+++ b/projects/core/src/icon/icon.element.scss
@@ -151,6 +151,10 @@ svg {
   --badge-color: #{$cds-alias-status-info};
 }
 
+:host([badge='neutral']) {
+  --badge-color: #{$cds-alias-status-neutral};
+}
+
 // alert colors
 :host([badge='inherit-triangle']) {
   --badge-color: currentColor;

--- a/projects/core/src/icon/icon.element.ts
+++ b/projects/core/src/icon/icon.element.ts
@@ -110,7 +110,7 @@ export class CdsIcon extends LitElement {
 
   /**
    * Changes color of icon fills and outlines
-   * @type {info | success | warning | danger}
+   * @type {neutral | info | success | warning | danger}
    */
   @property({ type: String })
   status: StatusTypes;

--- a/projects/core/src/icon/icon.element.ts
+++ b/projects/core/src/icon/icon.element.ts
@@ -140,7 +140,7 @@ export class CdsIcon extends LitElement {
    * By default, the badge displays a 'danger' dot (a red-colored dot).
    *
    * Setting the badge to 'false' or removing the attribute will remove the default icon badge.
-   * @type {info | success | warning | danger | inherit | warning-triangle | inherit-triangle}
+   * @type {neutral | info | success | warning | danger | inherit | warning-triangle | inherit-triangle}
    */
   @property({ type: String })
   badge: StatusTypes | 'inherit' | 'warning-triangle' | 'inherit-triangle' | true | false;

--- a/projects/core/src/icon/icon.stories.ts
+++ b/projects/core/src/icon/icon.stories.ts
@@ -266,6 +266,13 @@ export function badges() {
     <cds-icon
       shape="user"
       size="lg"
+      badge="neutral"
+      role="img"
+      aria-label="This is an example of an icon of a user with a gray neutral badge"
+    ></cds-icon>
+    <cds-icon
+      shape="user"
+      size="lg"
       badge="warning-triangle"
       role="img"
       aria-label="This is an example of an icon of a user with a dark orange triangle indicating something may be wrong"
@@ -556,6 +563,7 @@ export function darkTheme() {
         <cds-icon shape="user" size="lg" badge="success"></cds-icon>
         <cds-icon shape="user" size="lg" badge="danger"></cds-icon>
         <cds-icon shape="user" size="lg" badge="warning"></cds-icon>
+        <cds-icon shape="user" size="lg" badge="neutral"></cds-icon>
         <cds-icon shape="user" size="lg" badge="warning-triangle"></cds-icon>
       </div>
 

--- a/projects/core/src/icon/icon.stories.ts
+++ b/projects/core/src/icon/icon.stories.ts
@@ -320,6 +320,13 @@ export function status() {
       role="img"
       aria-label="This is an example of a red icon of a user indicating danger or an error"
     ></cds-icon>
+    <cds-icon
+      shape="user"
+      status="neutral"
+      size="lg"
+      role="img"
+      aria-label="This is an example of a gray icon of a user indicating a neutral status"
+    ></cds-icon>
 
     <cds-icon
       shape="user"
@@ -360,6 +367,14 @@ export function status() {
       role="img"
       aria-label="This is an example of an icon of a user completely filled in with a red color indicating danger or an error"
     ></cds-icon>
+    <cds-icon
+      shape="user"
+      status="neutral"
+      size="lg"
+      solid
+      role="img"
+      aria-label="This is an example of an icon of a user completely filled in with a gray color indicating a neutral status"
+    ></cds-icon>
   `;
 }
 
@@ -372,12 +387,14 @@ export function statusInverse() {
       <cds-icon shape="user" inverse status="success" size="lg" role="img" aria-label="This is an example of a green icon of a user on a dark background indicating success"></cds-icon>
       <cds-icon shape="user" inverse status="warning" size="lg" role="img" aria-label="This is an example of a dark orange icon of a user on a dark background indicating a warning"></cds-icon>
       <cds-icon shape="user" inverse status="danger" size="lg" role="img" aria-label="This is an example of a red icon of a user on a dark background indicating danger or an error"></cds-icon>
+      <cds-icon shape="user" inverse status="neutral" size="lg" role="img" aria-label="This is an example of a gray icon of a user on a dark background indicating a neutral status"></cds-icon>
 
       <cds-icon shape="user" inverse size="lg" solid role="img" aria-label="This is an example of an icon of a user completely filled in with the default color of the surrounding text on a dark background"></cds-icon>
       <cds-icon shape="user" inverse status="info" size="lg" solid role="img" aria-label="This is an example of an icon of a user completely filled in with the blue, informational color on a dark background"></cds-icon>
       <cds-icon shape="user" inverse status="success" size="lg" solid role="img" aria-label="This is an example of an icon of a user on a dark background completely filled in with a green color indicating success"></cds-icon>
       <cds-icon shape="user" inverse status="warning" size="lg" solid role="img" aria-label="This is an example of an icon of a user on a dark background completely filled in with a dark orange color indicating warning"></cds-icon>
       <cds-icon shape="user" inverse status="danger" size="lg" solid role="img" aria-label="This is an example of an icon of a user on a dark background completely filled in with a red color indicating danger or an error"></cds-icon></cds-icon>
+      <cds-icon shape="user" inverse status="neutral" size="lg" solid role="img" aria-label="This is an example of an icon of a user on a dark background completely filled in with a gray color indicating a neutral status"></cds-icon></cds-icon>
     </cds-demo>
   `;
 }
@@ -548,6 +565,7 @@ export function darkTheme() {
         <cds-icon shape="user" status="success" size="lg"></cds-icon>
         <cds-icon shape="user" status="warning" size="lg"></cds-icon>
         <cds-icon shape="user" status="danger" size="lg"></cds-icon>
+        <cds-icon shape="user" status="neutral" size="lg"></cds-icon>
       </div>
 
       <div cds-layout="horizontal gap:sm">
@@ -556,6 +574,7 @@ export function darkTheme() {
         <cds-icon shape="user" status="success" size="lg" solid></cds-icon>
         <cds-icon shape="user" status="warning" size="lg" solid></cds-icon>
         <cds-icon shape="user" status="danger" size="lg" solid></cds-icon>
+        <cds-icon shape="user" status="neutral" size="lg" solid></cds-icon>
       </div>
     </div>
   `;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

Not applicable here: this is a styling fix, badge/status features are already covered by tests

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix (more like a missing style)
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current/new behavior?

Before | After
--- | ---
<img width="451" alt="Screenshot 2023-07-05 at 6 33 14 PM" src="https://github.com/vmware-clarity/core/assets/113730/a5d4bfa9-b1ba-4e05-a09f-15e6e0366701"> | <img width="533" alt="Screenshot 2023-07-05 at 6 21 53 PM" src="https://github.com/vmware-clarity/core/assets/113730/503783fc-0f40-4b0b-ace8-83c079defc29">
<img width="308" alt="Screenshot 2023-07-05 at 6 33 18 PM" src="https://github.com/vmware-clarity/core/assets/113730/bb792e1c-f905-4940-b038-98a75efea7a2"> | <img width="331" alt="Screenshot 2023-07-05 at 6 29 40 PM" src="https://github.com/vmware-clarity/core/assets/113730/2da7b48b-297f-4889-8c9b-bf64e5ce5892">
<img width="335" alt="Screenshot 2023-07-05 at 6 33 40 PM" src="https://github.com/vmware-clarity/core/assets/113730/48410d5b-c28c-496d-b1ad-68a283df29c7"> | <img width="396" alt="Screenshot 2023-07-05 at 6 34 37 PM" src="https://github.com/vmware-clarity/core/assets/113730/dedc5604-6300-4391-b699-1fd9d5cbcd6a">


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
