### PR TITLE
fix(react): fix jsdom react testing with vitest

### DIFF
--- a/projects/core/custom-elements.json
+++ b/projects/core/custom-elements.json
@@ -46506,6 +46506,10 @@
         {
           "kind": "function",
           "name": "isJestTest"
+        },
+        {
+          "kind": "function",
+          "name": "isJsdomTest"
         }
       ],
       "exports": [
@@ -46522,6 +46526,14 @@
           "name": "isJestTest",
           "declaration": {
             "name": "isJestTest",
+            "module": "internal/utils/environment.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "isJsdomTest",
+          "declaration": {
+            "name": "isJsdomTest",
             "module": "internal/utils/environment.js"
           }
         }

--- a/projects/core/src/internal/decorators/animate.ts
+++ b/projects/core/src/internal/decorators/animate.ts
@@ -12,11 +12,11 @@ import {
   PRIVATE_ANIMATION_STATUS_ATTR_NAME,
 } from '../motion/interfaces.js';
 import { runPropertyAnimations } from '../motion/utils.js';
-import { isJestTest } from '../utils/environment.js';
+import { isJsdomTest } from '../utils/environment.js';
 
 // decorator factory that extends the component constructor to inject animations code into it
 export function animate(config: PropertyDrivenAnimation) {
-  if (isJestTest()) {
+  if (isJsdomTest()) {
     return function () {
       // jsdom doesn't like the class returned from the decorator below
       // do nothing

--- a/projects/core/src/internal/utils/environment.ts
+++ b/projects/core/src/internal/utils/environment.ts
@@ -13,3 +13,12 @@ export function isBrowser(win = window) {
 export function isJestTest() {
   return (globalThis as any)?.process?.env?.JEST_WORKER_ID !== undefined;
 }
+
+export function isJsdomTest() {
+  // This is to avoid breaking existing usage: prior to the addition of this function, isJestTest()
+  // was used to determine whether the execution environment was a test using Jsdom.
+  if (isJestTest()) {
+    return true;
+  }
+  return (globalThis as any)?.process?.env?.NODE_ENV === 'test' && navigator?.userAgent?.includes('jsdom');
+}

--- a/projects/core/src/internal/utils/events.ts
+++ b/projects/core/src/internal/utils/events.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { isJestTest } from './environment.js';
+import { isJsdomTest } from './environment.js';
 
 export function stopEvent(event: Event) {
   event.preventDefault();
@@ -31,8 +31,8 @@ export const getElementUpdates = (
 
   const updatedProp = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(element), propertyKey) as any;
 
-  //  Jest and JSDom breaks defining a new property, so skip
-  if (updatedProp && !isJestTest()) {
+  //  Tests using JSDom break defining a new property, so skip
+  if (updatedProp && !isJsdomTest()) {
     Object.defineProperty(element, propertyKey, {
       get: updatedProp.get,
       set: val => {


### PR DESCRIPTION
Replace isJestTest with more general isJsdomTest.

The code had a workaround to ensure compatibility with Jest + Jsdom. The value of `process.env.JEST_WORKER_ID` was used to determine whether the execution environment was Jest. To ensure compatibility with other test frameworks, and in particular Vitest, we use a more general test to determine whether to apply the workaround.

Fixes #260

## PR Checklist

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #260 

## What is the new behavior?

No errors when running tests with non-jest testing frameworks (e.g. vitest).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

