### PR TITLE
feat(ng): add missing object-container-background-inverse colors

### DIFF
--- a/projects/core/build/tokens.ts
+++ b/projects/core/build/tokens.ts
@@ -573,6 +573,11 @@ const aliases = {
         tint: token(color.construction[50]),
         shade: token(color.construction[100]),
         dark: token(color.construction[200]),
+        inverse: {
+          value: token(color.construction[200]),
+          tint: token(color.construction[100]),
+          shade: token(color.construction[300]),
+        },
       },
       borderColor: token(color.construction[200]),
     },

--- a/projects/core/src/index.performance.ts
+++ b/projects/core/src/index.performance.ts
@@ -8,14 +8,14 @@ import { testBundleSize } from 'web-test-runner-performance/browser.js';
 
 describe('performance', () => {
   it(`should meet maximum individual css bundle size limits`, async () => {
-    expect((await testBundleSize('@cds/core/global.min.css')).kb).toBeLessThan(8.716);
-    expect((await testBundleSize('@cds/core/styles/theme.dark.min.css')).kb).toBeLessThan(0.79);
+    expect((await testBundleSize('@cds/core/global.min.css')).kb).toBeLessThan(8.825);
+    expect((await testBundleSize('@cds/core/styles/theme.dark.min.css')).kb).toBeLessThan(0.8);
     expect((await testBundleSize('@cds/core/list/list.min.css')).kb).toBeLessThan(0.5);
 
     // contained in @cds/core/global.min.css
     expect((await testBundleSize('@cds/core/styles/module.layout.min.css')).kb).toBeLessThan(4.6);
     expect((await testBundleSize('@cds/core/styles/module.reset.min.css')).kb).toBeLessThan(0.5);
-    expect((await testBundleSize('@cds/core/styles/module.tokens.min.css')).kb).toBeLessThan(3.042);
+    expect((await testBundleSize('@cds/core/styles/module.tokens.min.css')).kb).toBeLessThan(3.06);
     expect((await testBundleSize('@cds/core/styles/module.typography.min.css')).kb).toBeLessThan(1.616);
   });
 

--- a/projects/core/src/styles/theme.dark.scss
+++ b/projects/core/src/styles/theme.dark.scss
@@ -21,6 +21,9 @@
   --cds-alias-object-container-background: #{$cds-global-color-construction-900};
   --cds-alias-object-container-background-tint: #{$cds-global-color-construction-1000};
   --cds-alias-object-container-background-shade: #{$cds-global-color-construction-800};
+  --cds-alias-object-container-background-inverse: #{$cds-global-color-construction-600};
+  --cds-alias-object-container-background-inverse-tint: #{$cds-global-color-construction-500};
+  --cds-alias-object-container-background-inverse-shade: #{$cds-global-color-construction-800};
   --cds-alias-object-container-border-color: #{$cds-global-color-black};
   --cds-alias-object-overlay-background: #{$cds-global-color-construction-900};
   --cds-alias-object-border-color: #{$cds-global-color-construction-500};


### PR DESCRIPTION
Adds new colors to the token system for container background inverse.