### PR TITLE
chore(ci): change comment format to get rid of npm start error

### DIFF
--- a/projects/core/src/accordion/accordion-header.element.scss
+++ b/projects/core/src/accordion/accordion-header.element.scss
@@ -7,12 +7,11 @@
 @import './../styles/tokens/generated/index';
 @import './../styles/mixins/mixins';
 
-/*
- * The variables `--box-shadow`, `--icon-visibility`, and `--icon-margin` are
- * included to provide users with the flexibility to extend the accordion
- * component, enabling them to create a stepper component that aligns with the
- * style of the ng-clarity stepper.
- */
+// The variables `--box-shadow`, `--icon-visibility`, and `--icon-margin` are
+// included to provide users with the flexibility to extend the accordion
+// component, enabling them to create a stepper component that aligns with the
+// style of the ng-clarity stepper.
+
 :host {
   --color: #{$cds-alias-object-interaction-color};
   --background: #{$cds-alias-object-container-background-tint};


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: CDE-1557

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This PR is fixing the following error that occurs on `npm start`:

![image](https://github.com/vmware-clarity/core/assets/132376042/4b2f59b2-2b51-47e0-a480-b6116700b08a)

A more optimal solution would be to check the osso library and our rollup.utils.js file and fix the comment issue fully

