### PR TITLE
fix(a11y): icon button-black focus outline does not meet 3:1 contrast minimum in dark theme

### DIFF
--- a/projects/core/src/button-action/button-action.element.scss
+++ b/projects/core/src/button-action/button-action.element.scss
@@ -107,5 +107,6 @@ cds-icon,
 @media (-webkit-min-device-pixel-ratio: 0) {
   :host(:focus) .private-host::after {
     outline-color: -webkit-focus-ring-color;
+    outline-style: auto;
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [CDE-1604](https://jira.eng.vmware.com/browse/CDE-1604)

## What is the new behavior?
The focus outline colour defaults to the `webkit-focus-ring-color` in dark theme on windows chrome.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
