### PR TITLE
chore(file): remove "private" comment from `clearFiles` method

### DIFF
--- a/projects/core/src/file/file.element.ts
+++ b/projects/core/src/file/file.element.ts
@@ -77,7 +77,6 @@ export class CdsFile extends CdsControl {
     });
   }
 
-  /** @private */
   clearFiles(fireEvent = true) {
     this.buttonLabelForSelection = '';
     this.inputControl.value = '';


### PR DESCRIPTION
Since the `cds-file` component ignores non-user `change` events, the `clearFiles` method is the only way to programmatically clear the file input.