### PR TITLE
fix: use construction value for new selected tokens

### DIFF
--- a/projects/core/src/styles/theme.dark.scss
+++ b/projects/core/src/styles/theme.dark.scss
@@ -61,8 +61,8 @@
   --cds-alias-object-interaction-background-hover: #{$cds-global-color-construction-800};
   --cds-alias-object-interaction-background-active: #{$cds-global-color-construction-600};
   --cds-alias-object-interaction-background-selected: #{$cds-global-color-blue-900};
-  --cds-alias-object-interaction-background-selected-active: #{$cds-global-color-blue-600};
-  --cds-alias-object-interaction-background-selected-hover: #{$cds-global-color-blue-700};
+  --cds-alias-object-interaction-background-selected-active: #{$cds-global-color-construction-600};
+  --cds-alias-object-interaction-background-selected-hover: #{$cds-global-color-construction-700};
   --cds-alias-object-interaction-background-disabled: #{$cds-global-color-construction-700};
   --cds-alias-object-interaction-background-highlight: #{$cds-global-color-blue-400};
   --cds-alias-object-interaction-border-color: #{$cds-global-color-construction-300};


### PR DESCRIPTION
Edit the values of the new tokens to use `construction` instead of `blue` #310 