### PR TITLE
fix(typography): use surrounding font size for inline code

### DIFF
--- a/projects/core/src/styles/typography/_typography.scss
+++ b/projects/core/src/styles/typography/_typography.scss
@@ -224,7 +224,6 @@ body[cds-text*='body'] {
 [cds-text~='code'] {
   color: $cds-alias-status-danger;
   font-family: monospace;
-  font-size: 1.1em;
 }
 
 // hr


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
`cds-text~='code'` have larger than surrounding font size text.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: CDE-1660

## What is the new behavior?
`cds-text~='code'` have same as the than surrounding font size text.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
