### PR TITLE
fix(tokens): remove alt status from dark theme

### DIFF
--- a/projects/core/src/styles/theme.dark.scss
+++ b/projects/core/src/styles/theme.dark.scss
@@ -119,9 +119,6 @@
   --cds-alias-status-danger-tint: #{$cds-global-color-red-800};
   --cds-alias-status-danger-shade: #{$cds-global-color-red-600};
   --cds-alias-status-danger-dark: #{$cds-global-color-red-900};
-  --cds-alias-status-alt: #{$cds-global-color-violet-700};
-  --cds-alias-status-alt-tint: #{$cds-global-color-violet-600};
-  --cds-alias-status-alt-shade: #{$cds-global-color-violet-900};
   --cds-alias-status-neutral: #{$cds-global-color-construction-300};
   --cds-alias-status-neutral-tint: #{$cds-global-color-construction-700};
   --cds-alias-status-neutral-shade: #{$cds-global-color-construction-400};


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Dark Theme:
- Token `--cds-alias-status-alt` have `--cds-global-color-violet-700` value.
- Token `--cds-alias-status-alt-tint` have `--cds-global-color-violet-600` value.
- Token `--cds-alias-status-alt-shade` have `--cds-global-color-violet-900` value.

Issue Number: CDE-2297

## What is the new behavior?
Alt status tokens have use the light theme colors.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
