### PR TITLE
fix(tokens): update dark theme warning and danger tint aliases

### DIFF
--- a/projects/core/src/styles/theme.dark.scss
+++ b/projects/core/src/styles/theme.dark.scss
@@ -112,11 +112,11 @@
   --cds-alias-status-success-tint: #{$cds-global-color-green-800};
   --cds-alias-status-success-shade: #{$cds-global-color-green-600};
   --cds-alias-status-warning: #{$cds-global-color-ochre-400};
-  --cds-alias-status-warning-tint: #{$cds-global-color-ochre-600};
+  --cds-alias-status-warning-tint: #{$cds-global-color-ochre-900};
   --cds-alias-status-warning-shade: #{$cds-global-color-ochre-500};
   --cds-alias-status-warning-dark: #{$cds-global-color-ochre-700};
   --cds-alias-status-danger: #{$cds-global-color-red-500};
-  --cds-alias-status-danger-tint: #{$cds-global-color-red-800};
+  --cds-alias-status-danger-tint: #{$cds-global-color-red-900};
   --cds-alias-status-danger-shade: #{$cds-global-color-red-600};
   --cds-alias-status-danger-dark: #{$cds-global-color-red-900};
   --cds-alias-status-neutral: #{$cds-global-color-construction-300};


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Dark theme: 
`--cds-alias-status-warning-tint` point to `--cds-global-color-ochre-600`
`--cds-alias-status-danger-tint` point to `--cds-global-color-red-800`

Issue Number: CDE-2339

## What is the new behavior?
`--cds-alias-status-warning-tint` point to `--cds-global-color-ochre-900`
`--cds-alias-status-danger-tint` point to `--cds-global-color-red-900`


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
