### PR TITLE
fix(tokens): warning status dark color for dark theme

### DIFF
--- a/projects/core/src/styles/theme.dark.scss
+++ b/projects/core/src/styles/theme.dark.scss
@@ -114,7 +114,7 @@
   --cds-alias-status-warning: #{$cds-global-color-ochre-400};
   --cds-alias-status-warning-tint: #{$cds-global-color-ochre-900};
   --cds-alias-status-warning-shade: #{$cds-global-color-ochre-500};
-  --cds-alias-status-warning-dark: #{$cds-global-color-ochre-700};
+  --cds-alias-status-warning-dark: #{$cds-global-color-ochre-600};
   --cds-alias-status-danger: #{$cds-global-color-red-500};
   --cds-alias-status-danger-tint: #{$cds-global-color-red-900};
   --cds-alias-status-danger-shade: #{$cds-global-color-red-600};


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
`--cds-alias-status-warning-dark` have `--cds-global-color-ochre-700` for dark theme.

Issue Number: CDE-2402

## What is the new behavior?
`--cds-alias-status-warning-dark` have `--cds-global-color-ochre-600` for dark theme.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
