### PR TITLE
fix(i18n): globalstateservice stateupdates memory leak

### DIFF
--- a/projects/core/src/alert/alert.performance.ts
+++ b/projects/core/src/alert/alert.performance.ts
@@ -16,7 +16,7 @@ describe('cds-badge performance', () => {
   `;
 
   it(`should bundle and treeshake alert`, async () => {
-    expect((await testBundleSize('@cds/core/alert/register.js')).kb).toBeLessThan(31.2);
+    expect((await testBundleSize('@cds/core/alert/register.js')).kb).toBeLessThan(31.3);
   });
 
   it(`should render 1 alert under 20ms`, async () => {

--- a/projects/core/src/grid/grid.performance.ts
+++ b/projects/core/src/grid/grid.performance.ts
@@ -11,7 +11,7 @@ import '@cds/core/grid/register.js';
 describe('cds-grid bundle performance', () => {
   it(`should bundle and treeshake component`, async () => {
     const result = await testBundleSize(`import '@cds/core/grid/register.js'`);
-    expect(result.kb).toBeLessThan(37.5);
+    expect(result.kb).toBeLessThan(37.6);
   });
 });
 

--- a/projects/core/src/index.performance.ts
+++ b/projects/core/src/index.performance.ts
@@ -56,6 +56,6 @@ describe('performance', () => {
       import '@cds/core/toggle/register.js';
       import '@cds/core/tree-view/register.js';`;
 
-    expect((await testBundleSize(bundle, { optimize: true })).kb).toBeLessThan(63.2);
+    expect((await testBundleSize(bundle, { optimize: true })).kb).toBeLessThan(63.3);
   });
 });

--- a/projects/core/src/internal/decorators/i18n.spec.ts
+++ b/projects/core/src/internal/decorators/i18n.spec.ts
@@ -43,6 +43,19 @@ class TestAlertI18nElement extends LitElement {
   }
 }
 
+/** @element test-extends-18n-element */
+@customElement('test-extends-18n-element')
+class TestExtendsI18nElement extends TestI18nElement {
+  @i18n() i18n = {
+    open: 'Open',
+    close: 'Close',
+  };
+
+  render() {
+    return html`<slot></slot>`;
+  }
+}
+
 describe('i18n decorator', () => {
   let testElement: HTMLElement;
   let component: TestI18nElement;
@@ -191,11 +204,19 @@ describe('helpers', () => {
   });
 });
 
-describe('unsubscribe', () => {
-  it('should unsubscribe from its subscription when the element is removed', async () => {
+describe('subscription', () => {
+  it('should be unsubscribed when the element is removed', async () => {
     const testElement = await createTestElement(
-      html` <test-alert-18n-element></test-alert-18n-element><test-alert-18n-element></test-alert-18n-element> `
+      html` <test-18n-element></test-18n-element><test-18n-element></test-18n-element> `
     );
+    removeTestElement(testElement);
+    expect((GlobalStateService.stateUpdates as any).subscriptions.length).toBe(0);
+  });
+
+  it('should be unsubscribed when the element extends an @i8n element and is removed', async () => {
+    const testElement = await createTestElement(html` <test-extends-18n-element></test-extends-18n-element> `);
+    const component = testElement.querySelector<TestExtendsI18nElement>('test-extends-18n-element');
+    expect(component.i18n).toEqual({ open: 'Open', close: 'Close' });
     removeTestElement(testElement);
     expect((GlobalStateService.stateUpdates as any).subscriptions.length).toBe(0);
   });

--- a/projects/core/src/internal/decorators/i18n.spec.ts
+++ b/projects/core/src/internal/decorators/i18n.spec.ts
@@ -11,6 +11,7 @@ import {
   getI18nUpdateStrategy,
   I18nService,
   I18nElement,
+  GlobalStateService,
 } from '@cds/core/internal';
 import { html, LitElement } from 'lit';
 import { componentIsStable, createTestElement, removeTestElement } from '@cds/core/test';
@@ -187,5 +188,15 @@ describe('helpers', () => {
       const expected = { update: false };
       expect(testMe).toEqual(expected);
     });
+  });
+});
+
+describe('unsubscribe', () => {
+  it('should unsubscribe from its subscription when the element is removed', async () => {
+    const testElement = await createTestElement(
+      html` <test-alert-18n-element></test-alert-18n-element><test-alert-18n-element></test-alert-18n-element> `
+    );
+    removeTestElement(testElement);
+    expect((GlobalStateService.stateUpdates as any).subscriptions.length).toBe(0);
   });
 });

--- a/projects/core/src/internal/decorators/i18n.ts
+++ b/projects/core/src/internal/decorators/i18n.ts
@@ -58,7 +58,7 @@ export function i18n() {
     const targetDisconnectedCallback: () => void = protoOrDescriptor.disconnectedCallback;
 
     function connectedCallback(this: any): void {
-      protoOrDescriptor.__i18nSub = GlobalStateService.stateUpdates.subscribe(update => {
+      this.__i18nSub = GlobalStateService.stateUpdates.subscribe(update => {
         if (update.key === 'i18nRegistry') {
           this.requestUpdate(name);
         }
@@ -70,7 +70,7 @@ export function i18n() {
     }
 
     function disconnectedCallback(this: any) {
-      protoOrDescriptor.__i18nSub.unsubscribe();
+      this.__i18nSub.unsubscribe();
 
       if (targetDisconnectedCallback) {
         targetDisconnectedCallback.apply(this);

--- a/projects/core/src/internal/decorators/i18n.ts
+++ b/projects/core/src/internal/decorators/i18n.ts
@@ -58,11 +58,13 @@ export function i18n() {
     const targetDisconnectedCallback: () => void = protoOrDescriptor.disconnectedCallback;
 
     function connectedCallback(this: any): void {
-      this.__i18nSub = GlobalStateService.stateUpdates.subscribe(update => {
-        if (update.key === 'i18nRegistry') {
-          this.requestUpdate(name);
-        }
-      });
+      if (!this.__i18nSub) {
+        this.__i18nSub = GlobalStateService.stateUpdates.subscribe(update => {
+          if (update.key === 'i18nRegistry') {
+            this.requestUpdate(name);
+          }
+        });
+      }
 
       if (targetConnectedCallback) {
         targetConnectedCallback.apply(this);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Demo: https://stackblitz.com/edit/clarity-core-angularjs-yk53hdkf?file=src%2Findex.js

Continuously clicking the Show/Hide button, find that `GlobalStateService.stateUpdates.subscriptions.length` is continuously increasing:
```
10
15
20
25
```
And the detached `cds-alert` DOM in the memory is also increasing:
![image](https://github.com/user-attachments/assets/e7318423-ffc0-49d1-a483-57371af6d636)

Affected components: which use `@i8n`, such as: alert, password...

### Root Cause
https://github.com/vmware-clarity/core/blob/a93e9a6a26bde82f9a84c41ad754d59f716ebf51/projects/core/src/internal/decorators/i18n.ts#L61

`__i18nSub` is on the `protoOrDescriptor` not the instance. Take alert as an example: all the alerts on the page will share the same `__i18nSub`, so if we remove all the alerts, only one `__i18nSub`(the newest one) will be unsubscribed. This causes the detached DOM to remain in memory.

There is also an issue that is caused by `extends`:
Assume that `class A` uses `@i18n`, and `class B` also uses `@i18n` while extending class A. In this case, an instance of `class A` will have two subscriptions when `connectedCallback`, but `__i18nSub` only saves the latest one. Therefore, only the latest subscription will be unsubscribed when `disconnectedCallback`.

So I added an if condition:
```ts
if (!this.__i18nSub) {
```
If we always use i18n as the name `@i18n() i18n`, it's okay, or do we need to keep these two subscriptions and unsubscribe from both of them when `disconnectedCallback`?

Issue Number: https://github.com/vmware-clarity/core/issues/67

## What is the new behavior?

Unsubscribe from its subscription when the element is removed

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
